### PR TITLE
chore(deps): update Rspack and Rsbuild to v2.2.0-beta.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,10 @@ settings:
   dedupePeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@swc/plugin-prefresh': 13.0.0
+  '@swc/plugin-styled-components': 13.0.0
+
 importers:
 
   .:
@@ -41,14 +45,14 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@swc/plugin-emotion':
-        specifier: ^14.12.0
-        version: 14.12.0
+        specifier: ^15.0.0
+        version: 15.0.0
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -65,8 +69,8 @@ importers:
   rsbuild/express:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -86,8 +90,8 @@ importers:
         specifier: ^9.3.2
         version: 9.3.2
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -101,8 +105,8 @@ importers:
   rsbuild/lit:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -124,13 +128,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)
+        version: 2.5.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -155,13 +159,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)
+        version: 2.5.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -185,11 +189,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -207,11 +211,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -226,11 +230,11 @@ importers:
         version: 10.29.2
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-preact':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(preact@10.29.2)
+        version: 2.0.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(preact@10.29.2)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -248,11 +252,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -276,11 +280,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -304,14 +308,14 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -338,14 +342,14 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-eslint':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(eslint@9.39.4)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(eslint@9.39.4)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -381,14 +385,14 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-mdx':
         specifier: ^1.1.2
-        version: 1.1.2(@rsbuild/core@2.1.6)(webpack@5.102.1)
+        version: 1.1.2(@rsbuild/core@2.2.0-beta.1)(webpack@5.102.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -415,14 +419,14 @@ importers:
         version: 4.3.0
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(webpack@5.102.1)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(webpack@5.102.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -446,11 +450,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -501,11 +505,11 @@ importers:
         version: 1.0.7(tailwindcss@3.4.19)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -529,14 +533,14 @@ importers:
         version: 1.9.13
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsbuild/plugin-solid':
         specifier: ^1.2.1
-        version: 1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.1.6)(solid-js@1.9.13)
+        version: 1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.2.0-beta.1)(solid-js@1.9.13)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -554,11 +558,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: 2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -585,11 +589,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: 2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -622,11 +626,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: 2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -662,14 +666,14 @@ importers:
         version: 6.4.2(css-to-react-native@3.2.0)(react-dom@19.2.7)(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@rsbuild/plugin-styled-components':
         specifier: ^1.6.2
-        version: 1.6.2(@rsbuild/core@2.1.6)
+        version: 1.6.2(@rsbuild/core@2.2.0-beta.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -696,14 +700,14 @@ importers:
         version: 5.1.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@swc/plugin-styled-jsx':
-        specifier: ^13.12.0
-        version: 13.12.0
+        specifier: ^14.0.0
+        version: 14.0.0
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -730,11 +734,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -758,11 +762,11 @@ importers:
         version: 5.56.0(@typescript-eslint/types@8.60.0)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-svelte':
         specifier: ^2.0.1
-        version: 2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.1.6)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)
+        version: 2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.2.0-beta.1)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -783,7 +787,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.11)(@tanstack/router-core@1.171.9)(csstype@3.2.3)(react-dom@19.2.7)(react@19.2.7)
       '@tanstack/react-start':
         specifier: ^1.168.19
-        version: 1.168.19(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
+        version: 1.168.19(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -798,14 +802,14 @@ importers:
         version: 4.3.0
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: ^2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(webpack@5.102.1)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(webpack@5.102.1)
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.3.0)
@@ -832,7 +836,7 @@ importers:
         version: 1.167.0(@tanstack/react-router@1.170.11)(@tanstack/router-core@1.171.9)(csstype@3.2.3)(react-dom@19.2.7)(react@19.2.7)
       '@tanstack/react-start':
         specifier: ^1.168.19
-        version: 1.168.19(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
+        version: 1.168.19(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
       dexie:
         specifier: ^4.0.10
         version: 4.4.3
@@ -853,14 +857,14 @@ importers:
         version: 5.0.14(@types/react@19.2.15)(react@19.2.7)(use-sync-external-store@1.6.0)
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: ^2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(webpack@5.102.1)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(webpack@5.102.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -884,7 +888,7 @@ importers:
         version: 1.167.0(@tanstack/router-core@1.171.9)(@tanstack/solid-router@1.170.11)(csstype@3.2.3)(solid-js@1.9.13)
       '@tanstack/solid-start':
         specifier: ^1.168.19
-        version: 1.168.19(@rsbuild/core@2.1.6)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(solid-js@1.9.13)(vite@8.0.16)(webpack@5.102.1)
+        version: 1.168.19(@rsbuild/core@2.2.0-beta.1)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(solid-js@1.9.13)(vite@8.0.16)(webpack@5.102.1)
       solid-js:
         specifier: ^1.9.12
         version: 1.9.13
@@ -896,17 +900,17 @@ importers:
         version: 4.3.0
     devDependencies:
       '@rsbuild/core':
-        specifier: ^2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: ^2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsbuild/plugin-solid':
         specifier: ^1.2.1
-        version: 1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.1.6)(solid-js@1.9.13)
+        version: 1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.2.0-beta.1)(solid-js@1.9.13)
       '@rsbuild/plugin-tailwindcss':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(webpack@5.102.1)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(webpack@5.102.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -917,11 +921,11 @@ importers:
   rsbuild/umd:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-umd':
         specifier: ^1.0.7
-        version: 1.0.7(@rsbuild/core@2.1.6)
+        version: 1.0.7(@rsbuild/core@2.2.0-beta.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -942,11 +946,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -970,11 +974,11 @@ importers:
         version: 3.5.35(typescript@5.9.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(vue@3.5.35)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -992,11 +996,11 @@ importers:
         version: 3.5.35(typescript@5.9.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(vue@3.5.35)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1020,11 +1024,11 @@ importers:
         version: 3.5.35(typescript@5.9.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(vue@3.5.35)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1048,14 +1052,14 @@ importers:
         version: 3.5.35(typescript@5.9.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-eslint':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(eslint@9.39.4)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(eslint@9.39.4)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(vue@3.5.35)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1088,14 +1092,14 @@ importers:
         version: 3.5.35(typescript@5.9.3)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-less':
         specifier: ^1.6.4
-        version: 1.6.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 1.6.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(vue@3.5.35)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1131,14 +1135,14 @@ importers:
         version: semver@7.8.1
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@rsdoctor/rspack-plugin':
         specifier: ^1.5.12
-        version: 1.5.12(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 1.5.12(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1178,19 +1182,19 @@ importers:
     devDependencies:
       '@rsdoctor/rspack-plugin':
         specifier: ^1.5.12
-        version: 1.5.12(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 1.5.12(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1272,13 +1276,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)
+        version: 2.5.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: ~2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1296,16 +1300,16 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: ^2.5.0
-        version: 2.5.0(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
+        version: 2.5.0(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
+        version: 2.5.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
       '@module-federation/storybook-addon':
         specifier: ^6.0.12
-        version: 6.0.12(@module-federation/sdk@2.5.0)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)(webpack@5.102.1)
+        version: 6.0.12(@module-federation/sdk@2.5.0)(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)(webpack@5.102.1)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
@@ -1323,13 +1327,13 @@ importers:
         version: 19.2.7(react@19.2.7)
       storybook:
         specifier: ^10.4.1
-        version: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+        version: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.6)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
+        version: 3.3.4(@rsbuild/core@2.2.0-beta.1)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.3)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)(webpack@5.102.1)
+        version: 3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.3)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)(webpack@5.102.1)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1345,13 +1349,13 @@ importers:
     devDependencies:
       '@module-federation/rsbuild-plugin':
         specifier: ^2.5.0
-        version: 2.5.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)
+        version: 2.5.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: ~2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1566,11 +1570,11 @@ importers:
   rslib/react-storybook:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: ~2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1594,13 +1598,13 @@ importers:
         version: 19.2.7(react@19.2.7)
       storybook:
         specifier: ^10.4.1
-        version: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+        version: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.6)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@5.9.3)
+        version: 3.3.4(@rsbuild/core@2.2.0-beta.1)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@5.9.3)
       storybook-react-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.3)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(webpack@5.102.1)
+        version: 3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.3)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(webpack@5.102.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1758,7 +1762,7 @@ importers:
     devDependencies:
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1808,11 +1812,11 @@ importers:
   rslib/vue-storybook:
     devDependencies:
       '@rsbuild/core':
-        specifier: ~2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: ~2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-vue':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(vue@3.5.35)
       '@rslib/core':
         specifier: ^0.22.0
         version: 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
@@ -1824,13 +1828,13 @@ importers:
         version: 10.4.1(storybook@10.4.1)
       storybook:
         specifier: ^10.4.1
-        version: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+        version: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       storybook-addon-rslib:
         specifier: ^3.3.4
-        version: 3.3.4(@rsbuild/core@2.1.6)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@5.9.3)
+        version: 3.3.4(@rsbuild/core@2.2.0-beta.1)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@5.9.3)
       storybook-vue3-rsbuild:
         specifier: ^3.3.4
-        version: 3.3.4(@babel/preset-env@7.29.7)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(vue@3.5.35)(webpack@5.102.1)
+        version: 3.3.4(@babel/preset-env@7.29.7)(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(vue@3.5.35)(webpack@5.102.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1857,13 +1861,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/basic-ts:
     dependencies:
@@ -1873,13 +1877,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1888,13 +1892,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -1916,64 +1920,64 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@swc/helpers':
         specifier: ^0.5.23
         version: 0.5.23
       '@swc/plugin-emotion':
-        specifier: ^14.12.0
-        version: 14.12.0
+        specifier: ^15.0.0
+        version: 15.0.0
       '@swc/plugin-loadable-components':
-        specifier: ^11.12.0
-        version: 11.12.0
+        specifier: ^12.0.0
+        version: 12.0.0
       '@swc/plugin-prefresh':
-        specifier: ^12.12.0
-        version: 12.12.0
+        specifier: 13.0.0
+        version: 13.0.0
       '@swc/plugin-relay':
-        specifier: ^12.12.0
-        version: 12.12.0
+        specifier: ^13.0.0
+        version: 13.0.0
       '@swc/plugin-remove-console':
-        specifier: ^12.12.0
-        version: 12.12.0
+        specifier: ^13.0.0
+        version: 13.0.0
       '@swc/plugin-styled-components':
-        specifier: ^12.12.1
-        version: 12.12.1
+        specifier: 13.0.0
+        version: 13.0.0
       '@swc/plugin-styled-jsx':
-        specifier: ^13.12.0
-        version: 13.12.0
+        specifier: ^14.0.0
+        version: 14.0.0
       '@swc/plugin-transform-imports':
-        specifier: ^12.12.0
-        version: 12.12.0
+        specifier: ^13.0.0
+        version: 13.0.0
 
   rspack/bundle-splitting:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/case-sensitive-paths-webpack-plugin:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       case-sensitive-paths-webpack-plugin:
         specifier: 2.4.0
         version: 2.4.0
@@ -1982,13 +1986,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/common-libs/lib1:
     devDependencies:
@@ -2018,16 +2022,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -2049,16 +2053,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -2076,28 +2080,28 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/css-parser-generator-options:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       sass-loader:
         specifier: ^16.0.8
-        version: 16.0.8(@rspack/core@2.1.4)(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.102.1)
+        version: 16.0.8(@rspack/core@2.2.0-beta.1)(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.102.1)
 
   rspack/dll:
     dependencies:
@@ -2107,13 +2111,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -2122,13 +2126,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       lodash:
         specifier: 4.18.1
         version: 4.18.1
@@ -2150,34 +2154,34 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@swc/plugin-emotion':
-        specifier: ^14.12.0
-        version: 14.12.0
+        specifier: ^15.0.0
+        version: 15.0.0
 
   rspack/eslint:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.7.0)
       eslint-rspack-plugin:
         specifier: ^5.0.1
-        version: 5.0.1(@rspack/core@2.1.4)(eslint@9.39.4)
+        version: 5.0.1(@rspack/core@2.2.0-beta.1)(eslint@9.39.4)
 
   rspack/express:
     dependencies:
@@ -2187,13 +2191,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -2209,25 +2213,25 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/generate-package-json-webpack-plugin:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       generate-package-json-webpack-plugin:
         specifier: ^2.7.0
         version: 2.7.0
@@ -2236,82 +2240,82 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/html-webpack-plugin:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 5.6.7(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
 
   rspack/http-import:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/inline-const:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/inline-const-enum:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/inline-enum:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/javascript-api:
     devDependencies:
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -2322,59 +2326,59 @@ importers:
   rspack/lazy-compilation-server:
     devDependencies:
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/library-cjs:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/library-esm:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/library-umd:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/license-webpack-plugin:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       license-webpack-plugin:
         specifier: ^4.0.2
         version: 4.0.2
@@ -2389,13 +2393,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/loader-compat:
     dependencies:
@@ -2411,13 +2415,13 @@ importers:
         version: 3.1.1(webpack@5.102.1)
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@svgr/webpack':
         specifier: 8.1.0
         version: 8.1.0(typescript@6.0.3)
@@ -2426,10 +2430,10 @@ importers:
         version: 10.5.0(postcss@8.5.15)
       babel-loader:
         specifier: 10.1.1
-        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       css-loader:
         specifier: 7.1.4
-        version: 7.1.4(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 7.1.4(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       file-loader:
         specifier: 6.2.0
         version: 6.2.0(webpack@5.102.1)
@@ -2438,13 +2442,13 @@ importers:
         version: 0.5.7
       less-loader:
         specifier: 12.3.3
-        version: 12.3.3(@rspack/core@2.1.4)(less@4.6.4)(webpack@5.102.1)
+        version: 12.3.3(@rspack/core@2.2.0-beta.1)(less@4.6.4)(webpack@5.102.1)
       node-loader:
         specifier: 2.1.0
         version: 2.1.0(webpack@5.102.1)
       postcss-loader:
         specifier: 8.2.1
-        version: 8.2.1(@rspack/core@2.1.4)(postcss@8.5.15)(typescript@6.0.3)(webpack@5.102.1)
+        version: 8.2.1(@rspack/core@2.2.0-beta.1)(postcss@8.5.15)(typescript@6.0.3)(webpack@5.102.1)
       raw-loader:
         specifier: 4.0.2
         version: 4.0.2(webpack@5.102.1)
@@ -2453,7 +2457,7 @@ importers:
         version: 1.100.0
       sass-loader:
         specifier: 16.0.8
-        version: 16.0.8(@rspack/core@2.1.4)(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.102.1)
+        version: 16.0.8(@rspack/core@2.2.0-beta.1)(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.102.1)
       source-map-loader:
         specifier: 5.0.0
         version: 5.0.0(webpack@5.102.1)
@@ -2465,7 +2469,7 @@ importers:
         version: 0.64.0
       stylus-loader:
         specifier: 8.1.3
-        version: 8.1.3(@rspack/core@2.1.4)(stylus@0.64.0)(webpack@5.102.1)
+        version: 8.1.3(@rspack/core@2.2.0-beta.1)(stylus@0.64.0)(webpack@5.102.1)
       svg-react-loader:
         specifier: 0.4.6
         version: 0.4.6
@@ -2500,19 +2504,19 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 5.6.7(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -2534,19 +2538,19 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 5.6.7(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -2571,16 +2575,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -2602,19 +2606,19 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 5.6.7(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -2636,19 +2640,19 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 5.6.7(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -2673,16 +2677,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -2698,13 +2702,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/monaco-editor-ts-react:
     dependencies:
@@ -2723,13 +2727,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -2747,13 +2751,13 @@ importers:
     dependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       monaco-editor:
         specifier: ^0.55.1
         version: 0.55.1
@@ -2765,25 +2769,25 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/nest-alias:
     dependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       lib1:
         specifier: workspace:*
         version: link:../common-libs/lib1
@@ -2821,13 +2825,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -2895,25 +2899,25 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/node-polyfill:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       node-polyfill-webpack-plugin:
         specifier: ^4.1.0
         version: 4.1.0(webpack@5.102.1)
@@ -2925,13 +2929,13 @@ importers:
         version: 1.14.2(encoding@0.1.13)(isolated-vm@4.7.2)(webpack@5.102.1)
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/polyfill:
     dependencies:
@@ -2941,31 +2945,31 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/postcss-loader:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       autoprefixer:
         specifier: 10.5.0
         version: 10.5.0(postcss@8.5.15)
       postcss-loader:
         specifier: 8.2.1
-        version: 8.2.1(@rspack/core@2.1.4)(postcss@8.5.15)(typescript@6.0.3)(webpack@5.102.1)
+        version: 8.2.1(@rspack/core@2.2.0-beta.1)(postcss@8.5.15)(typescript@6.0.3)(webpack@5.102.1)
       postcss-plugin-px2rem:
         specifier: 0.8.1
         version: 0.8.1
@@ -2987,13 +2991,13 @@ importers:
         version: 4.0.6(@prefresh/babel-plugin@0.5.3)(preact@10.29.2)(webpack@5.102.1)
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/preact-refresh:
     dependencies:
@@ -3012,31 +3016,31 @@ importers:
         version: 1.2.1
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-preact-refresh':
         specifier: ^1.1.6
         version: 1.1.6(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)
       '@swc/plugin-prefresh':
-        specifier: ^12.12.0
-        version: 12.12.0
+        specifier: 13.0.0
+        version: 13.0.0
 
   rspack/proxy:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/react:
     dependencies:
@@ -3055,13 +3059,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/react-compiler-babel:
     dependencies:
@@ -3083,16 +3087,16 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       babel-loader:
         specifier: ^10.1.1
-        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -3120,13 +3124,13 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -3138,7 +3142,7 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
       babel-loader:
         specifier: ^10.1.1
-        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -3157,16 +3161,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -3197,16 +3201,16 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -3215,7 +3219,7 @@ importers:
         version: 19.2.3(@types/react@19.2.15)
       babel-loader:
         specifier: ^10.1.1
-        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       react-refresh:
         specifier: 0.18.0
         version: 0.18.0
@@ -3231,16 +3235,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -3268,13 +3272,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@types/cross-spawn':
         specifier: ^6.0.6
         version: 6.0.6
@@ -3295,7 +3299,7 @@ importers:
         version: 7.0.6
       rspack-manifest-plugin:
         specifier: ^5.2.1
-        version: 5.2.1(@rspack/core@2.1.4)
+        version: 5.2.1(@rspack/core@2.2.0-beta.1)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3307,10 +3311,10 @@ importers:
         version: 0.5.23
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 7.1.4(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       less-loader:
         specifier: 12.3.3
-        version: 12.3.3(@rspack/core@2.1.4)(less@4.6.4)(webpack@5.102.1)
+        version: 12.3.3(@rspack/core@2.2.0-beta.1)(less@4.6.4)(webpack@5.102.1)
       normalize.css:
         specifier: 8.0.1
         version: 8.0.1
@@ -3323,13 +3327,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -3341,7 +3345,7 @@ importers:
         version: 0.5.23
       less-loader:
         specifier: 12.3.3
-        version: 12.3.3(@rspack/core@2.1.4)(less@4.6.4)(webpack@5.102.1)
+        version: 12.3.3(@rspack/core@2.2.0-beta.1)(less@4.6.4)(webpack@5.102.1)
       normalize.css:
         specifier: 8.0.1
         version: 8.0.1
@@ -3354,13 +3358,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -3378,17 +3382,17 @@ importers:
         version: 19.2.7(react@19.2.7)
       sass-loader:
         specifier: ^16.0.8
-        version: 16.0.8(@rspack/core@2.1.4)(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.102.1)
+        version: 16.0.8(@rspack/core@2.2.0-beta.1)(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.102.1)
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
@@ -3397,16 +3401,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       rspack-manifest-plugin:
         specifier: 5.2.1
-        version: 5.2.1(@rspack/core@2.1.4)
+        version: 5.2.1(@rspack/core@2.2.0-beta.1)
 
   rspack/rspack-rsc:
     dependencies:
@@ -3437,16 +3441,16 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -3455,13 +3459,13 @@ importers:
         version: 8.18.1
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 7.1.4(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       react-refresh:
         specifier: ^0.18.0
         version: 0.18.0
       react-server-dom-rspack:
         specifier: 0.0.2
-        version: 0.0.2(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)
+        version: 0.0.2(@rspack/core@2.2.0-beta.1)(react-dom@19.2.7)(react@19.2.7)
       run-script-webpack-plugin:
         specifier: ^0.2.3
         version: 0.2.3
@@ -3482,13 +3486,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@sentry/webpack-plugin':
         specifier: 5.3.0
         version: 5.3.0(encoding@0.1.13)(webpack@5.102.1)
@@ -3500,7 +3504,7 @@ importers:
         version: 7.29.7
       babel-loader:
         specifier: 10.1.1
-        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       babel-preset-solid:
         specifier: 1.9.12
         version: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.13)
@@ -3513,13 +3517,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/source-map-with-vscode-debugging:
     dependencies:
@@ -3535,25 +3539,25 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/stats:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/styled-components:
     dependencies:
@@ -3572,13 +3576,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@types/react':
         specifier: ^19.2.15
         version: 19.2.15
@@ -3593,13 +3597,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@tsconfig/svelte':
         specifier: ^5.0.8
         version: 5.0.8
@@ -3642,13 +3646,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@svgr/webpack':
         specifier: 8.1.0
         version: 8.1.0(typescript@6.0.3)
@@ -3660,19 +3664,19 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@tailwindcss/webpack':
         specifier: ^4.3.0
         version: 4.3.0(webpack@5.102.1)
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 7.1.4(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -3681,13 +3685,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@tailwindcss/postcss':
         specifier: ^4.3.0
         version: 4.3.0
@@ -3699,7 +3703,7 @@ importers:
         version: 8.5.15
       postcss-loader:
         specifier: 8.2.1
-        version: 8.2.1(@rspack/core@2.1.4)(postcss@8.5.15)(typescript@6.0.3)(webpack@5.102.1)
+        version: 8.2.1(@rspack/core@2.2.0-beta.1)(postcss@8.5.15)(typescript@6.0.3)(webpack@5.102.1)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.0
@@ -3708,13 +3712,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@tailwindcss/webpack':
         specifier: ^4.3.0
         version: 4.3.0(webpack@5.102.1)
@@ -3726,13 +3730,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       terser-webpack-plugin:
         specifier: 5.6.1
         version: 5.6.1(webpack@5.102.1)
@@ -3744,31 +3748,31 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/ts-checker-rspack-plugin:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
       ts-checker-rspack-plugin:
         specifier: ^1.3.1
-        version: 1.3.1(@rspack/core@2.1.4)(tslib@2.8.1)(typescript@5.9.3)
+        version: 1.3.1(@rspack/core@2.2.0-beta.1)(tslib@2.8.1)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3777,13 +3781,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/unplugin-auto-import:
     dependencies:
@@ -3793,19 +3797,19 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       html-webpack-plugin:
         specifier: 5.6.7
-        version: 5.6.7(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 5.6.7(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       rspack-vue-loader:
         specifier: ^17.5.1
-        version: 17.5.1(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 17.5.1(@rspack/core@2.2.0-beta.1)(vue@3.5.35)
       unplugin-auto-import:
         specifier: ^21.0.0
         version: 21.0.0(@vueuse/core@14.3.0)
@@ -3814,13 +3818,13 @@ importers:
     dependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@vanilla-extract/css':
         specifier: 1.20.1
         version: 1.20.1(babel-plugin-macros@3.1.0)
@@ -3832,7 +3836,7 @@ importers:
         version: 2.3.27(babel-plugin-macros@3.1.0)(webpack@5.102.1)
       html-webpack-plugin:
         specifier: ^5.6.7
-        version: 5.6.7(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 5.6.7(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       polished:
         specifier: ^4.3.1
         version: 4.3.1
@@ -3867,22 +3871,22 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       less:
         specifier: 4.6.4
         version: 4.6.4
       less-loader:
         specifier: ^12.3.3
-        version: 12.3.3(@rspack/core@2.1.4)(less@4.6.4)(webpack@5.102.1)
+        version: 12.3.3(@rspack/core@2.2.0-beta.1)(less@4.6.4)(webpack@5.102.1)
       rspack-vue-loader:
         specifier: ^17.5.1
-        version: 17.5.1(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 17.5.1(@rspack/core@2.2.0-beta.1)(vue@3.5.35)
 
   rspack/vue-jsx:
     dependencies:
@@ -3895,19 +3899,19 @@ importers:
         version: 7.29.7
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@vue/babel-plugin-jsx':
         specifier: 2.0.1
         version: 2.0.1(@babel/core@7.29.7)
       babel-loader:
         specifier: 10.1.1
-        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
 
   rspack/vue-tsx:
     dependencies:
@@ -3923,13 +3927,13 @@ importers:
         version: 7.29.7(@babel/core@7.29.7)
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -3938,10 +3942,10 @@ importers:
         version: 2.0.1(@babel/core@7.29.7)
       babel-loader:
         specifier: 10.1.1
-        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       rspack-vue-loader:
         specifier: ^17.5.1
-        version: 17.5.1(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 17.5.1(@rspack/core@2.2.0-beta.1)(vue@3.5.35)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3954,25 +3958,25 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 7.1.4(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       less:
         specifier: 4.6.4
         version: 4.6.4
       less-loader:
         specifier: ^12.3.3
-        version: 12.3.3(@rspack/core@2.1.4)(less@4.6.4)(webpack@5.102.1)
+        version: 12.3.3(@rspack/core@2.2.0-beta.1)(less@4.6.4)(webpack@5.102.1)
       rspack-vue-loader:
         specifier: ^17.5.1
-        version: 17.5.1(@rspack/core@2.1.4)(vue@3.5.35)
+        version: 17.5.1(@rspack/core@2.2.0-beta.1)(vue@3.5.35)
       style-loader:
         specifier: ^4.0.0
         version: 4.0.0(webpack@5.102.1)
@@ -3981,25 +3985,25 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/webpack-bundle-analyzer:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       webpack-bundle-analyzer:
         specifier: ^5.3.0
         version: 5.3.0
@@ -4008,13 +4012,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       webpack-stats-plugin:
         specifier: ^1.1.3
         version: 1.1.3
@@ -4023,13 +4027,13 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       remote-web-worker:
         specifier: 0.0.9
         version: 0.0.9
@@ -4038,29 +4042,29 @@ importers:
     dependencies:
       worker-rspack-loader:
         specifier: ^3.1.4
-        version: 3.1.4(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 3.1.4(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
 
   rspack/worklet:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       esbuild:
         specifier: 0.28.1
         version: 0.28.1
@@ -4118,14 +4122,14 @@ importers:
   rstest/browser-locator:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@rstest/adapter-rsbuild':
         specifier: ^0.10.3
-        version: 0.10.3(@rsbuild/core@2.1.6)(@rstest/core@0.10.3)
+        version: 0.10.3(@rsbuild/core@2.2.0-beta.1)(@rstest/core@0.10.3)
       '@rstest/browser':
         specifier: ^0.10.3
         version: 0.10.3(@rstest/core@0.10.3)(playwright@1.60.0)
@@ -4157,14 +4161,14 @@ importers:
   rstest/browser-rsbuild-react:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@rstest/adapter-rsbuild':
         specifier: ^0.10.3
-        version: 0.10.3(@rsbuild/core@2.1.6)(@rstest/core@0.10.3)
+        version: 0.10.3(@rsbuild/core@2.2.0-beta.1)(@rstest/core@0.10.3)
       '@rstest/browser':
         specifier: ^0.10.3
         version: 0.10.3(@rstest/core@0.10.3)(playwright@1.60.0)
@@ -4205,8 +4209,8 @@ importers:
   rstest/browser-rsbuild-vanilla:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rstest/browser':
         specifier: ^0.10.3
         version: 0.10.3(@rstest/core@0.10.3)(playwright@1.60.0)
@@ -4256,11 +4260,11 @@ importers:
   rstest/rsbuild-adapter:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rstest/adapter-rsbuild':
         specifier: ^0.10.3
-        version: 0.10.3(@rsbuild/core@2.1.6)(@rstest/core@0.10.3)
+        version: 0.10.3(@rsbuild/core@2.2.0-beta.1)(@rstest/core@0.10.3)
       '@rstest/core':
         specifier: ^0.10.3
         version: 0.10.3(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(happy-dom@20.9.0)(jsdom@27.4.0)
@@ -4277,14 +4281,14 @@ importers:
   rstest/rsbuild-preact:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-preact':
         specifier: ^2.0.0
-        version: 2.0.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(preact@10.29.2)
+        version: 2.0.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(preact@10.29.2)
       '@rstest/adapter-rsbuild':
         specifier: ^0.10.3
-        version: 0.10.3(@rsbuild/core@2.1.6)(@rstest/core@0.10.3)
+        version: 0.10.3(@rsbuild/core@2.2.0-beta.1)(@rstest/core@0.10.3)
       '@rstest/core':
         specifier: ^0.10.3
         version: 0.10.3(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(happy-dom@20.9.0)(jsdom@27.4.0)
@@ -4311,11 +4315,11 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-react':
         specifier: ^2.1.0
-        version: 2.1.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)
+        version: 2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)
       '@rstest/core':
         specifier: ^0.10.3
         version: 0.10.3(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(happy-dom@20.9.0)(jsdom@27.4.0)
@@ -4341,17 +4345,17 @@ importers:
   rstest/rsbuild-solid:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)
+        version: 2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsbuild/plugin-solid':
         specifier: ^1.2.1
-        version: 1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.1.6)(solid-js@1.9.13)
+        version: 1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.2.0-beta.1)(solid-js@1.9.13)
       '@rstest/adapter-rsbuild':
         specifier: ^0.10.3
-        version: 0.10.3(@rsbuild/core@2.1.6)(@rstest/core@0.10.3)
+        version: 0.10.3(@rsbuild/core@2.2.0-beta.1)(@rstest/core@0.10.3)
       '@rstest/core':
         specifier: ^0.10.3
         version: 0.10.3(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(happy-dom@20.9.0)(jsdom@27.4.0)
@@ -4371,14 +4375,14 @@ importers:
   rstest/rsbuild-svelte:
     devDependencies:
       '@rsbuild/core':
-        specifier: 2.1.6
-        version: 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rsbuild/plugin-svelte':
         specifier: ^2.0.1
-        version: 2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.1.6)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)
+        version: 2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.2.0-beta.1)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)
       '@rstest/adapter-rsbuild':
         specifier: ^0.10.3
-        version: 0.10.3(@rsbuild/core@2.1.6)(@rstest/core@0.10.3)
+        version: 0.10.3(@rsbuild/core@2.2.0-beta.1)(@rstest/core@0.10.3)
       '@rstest/core':
         specifier: ^0.10.3
         version: 0.10.3(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(happy-dom@20.9.0)(jsdom@27.4.0)
@@ -4421,19 +4425,19 @@ importers:
     devDependencies:
       '@rspack/cli':
         specifier: 2.1.4
-        version: 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
+        version: 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
       '@rspack/core':
-        specifier: 2.1.4
-        version: 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+        specifier: 2.2.0-beta.1
+        version: 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rspack/dev-server':
         specifier: 2.1.0
-        version: 2.1.0(@rspack/core@2.1.4)
+        version: 2.1.0(@rspack/core@2.2.0-beta.1)
       '@rspack/plugin-react-refresh':
         specifier: ^2.0.1
-        version: 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+        version: 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
       '@rstest/adapter-rspack':
         specifier: ^0.10.3
-        version: 0.10.3(@rspack/cli@2.1.4)(@rspack/core@2.1.4)(@rstest/core@0.10.3)
+        version: 0.10.3(@rspack/cli@2.1.4)(@rspack/core@2.2.0-beta.1)(@rstest/core@0.10.3)
       '@rstest/core':
         specifier: ^0.10.3
         version: 0.10.3(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(happy-dom@20.9.0)(jsdom@27.4.0)
@@ -5251,6 +5255,9 @@ packages:
   '@emnapi/core@1.11.2':
     resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
 
+  '@emnapi/core@1.11.3':
+    resolution: {integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==}
+
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
@@ -5260,6 +5267,9 @@ packages:
   '@emnapi/runtime@1.11.2':
     resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
@@ -5268,6 +5278,9 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@emnapi/wasi-threads@1.2.3':
+    resolution: {integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -7419,6 +7432,16 @@ packages:
       core-js:
         optional: true
 
+  '@rsbuild/core@2.2.0-beta.1':
+    resolution: {integrity: sha512-P6KOCAA1kgXBCTa4dx/zQV9Wi5uzMxOIledelrm853DJQVGUTs+z3sMII4BHfzLhE6+NsJFq+ohBlAnmyliKHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      core-js: '>= 3.0.0'
+    peerDependenciesMeta:
+      core-js:
+        optional: true
+
   '@rsbuild/plugin-babel@1.1.2':
     resolution: {integrity: sha512-qIZzosQlkj7VyFz8mmz1vAKDFlk79xrIvCRYzROqNwQHDXep+gd91nCnUPJdRPHrktzN8Yqa190CPTii3rON6w==}
     peerDependencies:
@@ -7680,6 +7703,11 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@rspack/binding-darwin-arm64@2.2.0-beta.1':
+    resolution: {integrity: sha512-B3PauVgzpYPVgHgzsiMi0SMuKuTpSPJf/bAUASIZ7v5N/nSNvX4Ag9NmgZ4wexL1ZCY5+IOs/Q4ZAtMimpFtJQ==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rspack/binding-darwin-x64@1.6.7':
     resolution: {integrity: sha512-DpQRxxTXkMMNPmBXeJBaAB8HmWKxH2IfvHv7vU+kBhJ3xdPtXU4/xBv1W3biluoNRG11gc1WLIgjzeGgaLCxmw==}
     cpu: [x64]
@@ -7692,6 +7720,11 @@ packages:
 
   '@rspack/binding-darwin-x64@2.1.4':
     resolution: {integrity: sha512-bz/AsCplLs+3fXULPQU9d4r8H4PdeljgHFyItvVIrA/NKZqzQ8sX0topf/zJVZAOtPH7GNnrKjq0/F0U2DHikQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rspack/binding-darwin-x64@2.2.0-beta.1':
+    resolution: {integrity: sha512-jmg+2GlW3W72I4n5UjOlQNcuq81FJnSIX1UB9+WYcSPZq7F0GBspFKZIiFXawA91H/YUPw7bwzbABV9ZZcv/DQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -7709,6 +7742,12 @@ packages:
 
   '@rspack/binding-linux-arm64-gnu@2.1.4':
     resolution: {integrity: sha512-x0HQTLU1MusCtNamuXxf3ayEPkvh9uuaq4wVyBqveRkn4FznSOoHUsxTAKMnjGARX+vdLV/y/SwWJRDp2RI4zw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-arm64-gnu@2.2.0-beta.1':
+    resolution: {integrity: sha512-ZzVCnZKiG4HrbvsLIRi/PIfAXdO77csafU51vcH0a1OHic46KJLjo++A1nCH19QJ6fmelD4ZW5Ozd4pXdugGIg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -7731,8 +7770,26 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-arm64-musl@2.2.0-beta.1':
+    resolution: {integrity: sha512-imlWzOnDRrKLL5kFBcB+B/PaJNpKGjVlwcfnDkeDjVqT8twnDSgjeqLiYrM3cgLCvk8zUQCkrkAIOGI+GyN8Mw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-ppc64-gnu@2.2.0-beta.1':
+    resolution: {integrity: sha512-duACKIuwYQg1/N6c9NrOcFJGa/Qb9XX48sxGSr1vk380UNyX0tHC9rs7kh/udtMgv8NfNrz91fSvVAR+VRT4Uw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@rspack/binding-linux-riscv64-gnu@2.1.4':
     resolution: {integrity: sha512-jYtQKtnDRaVfyasvTGY04Z7m+xDWZYVwAIEOB4hP7czM7FVLOMgHlMlvw/EgF0DNHrBthqbPfBIS2tP50CzpEA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-riscv64-gnu@2.2.0-beta.1':
+    resolution: {integrity: sha512-hrOQm1pFrzQtaVqplpI5pXsdkBwiWYhgrhi5OPr5X5lM59w5EeC6n0D/f2AP06GfBVhfM+7CmvTUQbMXAnQUSA==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -7742,6 +7799,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
+
+  '@rspack/binding-linux-riscv64-musl@2.2.0-beta.1':
+    resolution: {integrity: sha512-Q21lN9uL5Rw2FsBE4lTLXIFbbGca708JdlQnmKzuU3PxWTgPo+ntVMdjoLFLlkYZ10o+dQKzC4ucdQERrZKuug==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rspack/binding-linux-s390x-gnu@2.2.0-beta.1':
+    resolution: {integrity: sha512-cayNe4kvh92Gvj7PAG6x3IKFXxd+t37gZC3aKTksbyIyzgvNWnavuvgGy4iU0gviBkPoufy543UuSD3VOoJixg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
 
   '@rspack/binding-linux-x64-gnu@1.6.7':
     resolution: {integrity: sha512-iMrE0Q4IuYpkE0MjpaOVaUDYbQFiCRI9D3EPoXzlXJj4kJSdNheODpHTBVRlWt8Xp7UAoWuIFXCvKFKcSMm3aQ==}
@@ -7757,6 +7826,12 @@ packages:
 
   '@rspack/binding-linux-x64-gnu@2.1.4':
     resolution: {integrity: sha512-C53B3e6M4yzlYn4hDxR9cHZV+HqkfFGR0zuhH8QCfdBfN5KyGsmXmujiFU85ANEvBgf9CF8VreBQeJ20lyto/g==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rspack/binding-linux-x64-gnu@2.2.0-beta.1':
+    resolution: {integrity: sha512-KCTKFrsO9zN8qR64KkJhJJeB6djFGZ4Cu6fH1rMhfNztJtQxpKXS6oUJRbQZ4AvBxJs4qywIwxToKqVwlu1A8A==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -7779,6 +7854,12 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rspack/binding-linux-x64-musl@2.2.0-beta.1':
+    resolution: {integrity: sha512-dGwFTlo4GUWxLZEW1J6Nd02t4m0seJZv3IyyWX1AgUVptotw/p82RjNRvoChiWjCNk80qXSZsaq9dUc8aG/B0Q==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rspack/binding-wasm32-wasi@1.6.7':
     resolution: {integrity: sha512-yx88EFdE9RP3hh7VhjjW6uc6wGU0KcpOcZp8T8E/a+X8L98fX0aVrtM1IDbndhmdluIMqGbfJNap2+QqOCY9Mw==}
     cpu: [wasm32]
@@ -7789,6 +7870,10 @@ packages:
 
   '@rspack/binding-wasm32-wasi@2.1.4':
     resolution: {integrity: sha512-0P1WZEfu7JOPzD/jQfk9U/6gnRFc7RpvYCQaYZVVYZNJ2gU6O0/yLegRGKNK/2L0zjYwiD0ynhOIBVUUERf5Pw==}
+    cpu: [wasm32]
+
+  '@rspack/binding-wasm32-wasi@2.2.0-beta.1':
+    resolution: {integrity: sha512-IYjRonL0MS4Tn0jjFpTSY4bFJHSRiFyj/fFoTZKdweBRDEpZ/AEPfTGRPwjhR6loyK+Uzrv7BY2N6QZo500hmg==}
     cpu: [wasm32]
 
   '@rspack/binding-win32-arm64-msvc@1.6.7':
@@ -7803,6 +7888,11 @@ packages:
 
   '@rspack/binding-win32-arm64-msvc@2.1.4':
     resolution: {integrity: sha512-+aStQipk1EakLRPfD+/aQbtmTXfxqSWetcRRDWV3cAsD4ebv1tF8FLKYY1PCaFpQbX1FxzCBGF0KHxkAsi9cxA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rspack/binding-win32-arm64-msvc@2.2.0-beta.1':
+    resolution: {integrity: sha512-BHQQ/UOBsiuf0A4+ihsN8/yb0FhFYBgdd3t8OX8LWi1BjKM3NxcX1Al/NYKBjb/ZmI+SWc9prAC1bpAKIXvizw==}
     cpu: [arm64]
     os: [win32]
 
@@ -7821,6 +7911,11 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@rspack/binding-win32-ia32-msvc@2.2.0-beta.1':
+    resolution: {integrity: sha512-OFO76oyeI+yxQXSwuJwpctcAtlsS2rO1MkQuOOoN6AeUEzc9k+zJucDadrZSOBNd2KNWdUVybwq4IWonKJrp5g==}
+    cpu: [ia32]
+    os: [win32]
+
   '@rspack/binding-win32-x64-msvc@1.6.7':
     resolution: {integrity: sha512-8xlbuJQtYktlBjZupOHlO8FeZqSIhsV3ih7xBSiOYar6LI6uQzA7XiO3I5kaPSDirBMMMKv1Z4rKCxWx10a3TQ==}
     cpu: [x64]
@@ -7836,6 +7931,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rspack/binding-win32-x64-msvc@2.2.0-beta.1':
+    resolution: {integrity: sha512-svluZTxJ+Ba1qoQPJy/nV2Rv/iI4awEakeEHS8fQHvcbAgELaxA+m9sjaIXjUD0jrY3DuLuUEwjKBqsCHLEHsA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rspack/binding@1.6.7':
     resolution: {integrity: sha512-7ICabuBN3gHc6PPN52+m1kruz3ogiJjg1C0gSWdLRk18m/4jlcM2aAy6wfXjgODJdB0Yh2ro/lIpBbj+AYWUGA==}
 
@@ -7844,6 +7944,9 @@ packages:
 
   '@rspack/binding@2.1.4':
     resolution: {integrity: sha512-iye4BaTYtTt0qa39avWwEsUobVxFNhQHr6B8reFeKU7sdaZsC9LUoDR8JAt5gOnbnzFMPdKgrdU/VzkC6rXbIg==}
+
+  '@rspack/binding@2.2.0-beta.1':
+    resolution: {integrity: sha512-yPjiUiM3nFEWlOFJmcFfMkSAavkPxjzSgfSpJNm07v1VvNCMG68sapcvN6bm7ZjMUV2NIPePqfJzjB6Rt1xpsQ==}
 
   '@rspack/cli@2.1.4':
     resolution: {integrity: sha512-DYFvcDwL8jzqPV+7zt7DKpq2Fsk7ZtK8YswhTTje6iaIwvtzAPLFI3BsG6YrQ3yfMj7jqjSe4Vb5MDPCxR/g4A==}
@@ -7878,6 +7981,18 @@ packages:
 
   '@rspack/core@2.1.4':
     resolution: {integrity: sha512-lpJgtr+JAXuDAMBJfRJ1LHyWVuYJyhZu6L6aj9t4lipUU03qwakHnzn3vwSCr68PsVvVPzR6NbJE1gJienSV0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
+      '@swc/helpers': ^0.5.23
+    peerDependenciesMeta:
+      '@module-federation/runtime-tools':
+        optional: true
+      '@swc/helpers':
+        optional: true
+
+  '@rspack/core@2.2.0-beta.1':
+    resolution: {integrity: sha512-nKecuncGsg+Ay3nrgmqB/hfvNe4d95qHn4qr9neAOIGTcHmMF4ZZU6PtoNqKO6wCspTsvJN6OhsosIV7RQgwZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@module-federation/runtime-tools': ^0.24.1 || ^2.0.0
@@ -8470,29 +8585,29 @@ packages:
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
 
-  '@swc/plugin-emotion@14.12.0':
-    resolution: {integrity: sha512-lyAQgTeDkowq/4+8JYaviVOL4jXSdObz+uuk84DjM0z4qoiMpI6xoDVp7/tjWeVjmLc2U6Qp3hDuwWMZ5xe88Q==}
+  '@swc/plugin-emotion@15.0.0':
+    resolution: {integrity: sha512-B0L0KuItii5XatOskjeFW4kNPXYEDo5JYm+k5Lze3LEY46q4L7foVkXiUFbNn0GjbKJCOv+nU2nM57k4LYLbHw==}
 
-  '@swc/plugin-loadable-components@11.12.0':
-    resolution: {integrity: sha512-zZr0KLZRBQKe88WgigSyE7qH+8CYIcQf9SaBTmShaly7NwZlfC8LrbdTu5bocc00Cb3ulzTcJixqAnSTfBDcOA==}
+  '@swc/plugin-loadable-components@12.0.0':
+    resolution: {integrity: sha512-3vdbr0k5NQ0W4KgIx6LrFvjKwDyMPWbeHBncfFT7Fo2IKyo7513CXMCkx6KEUEsPzTJZRhHx0pFyt2hPWnfpEA==}
 
-  '@swc/plugin-prefresh@12.12.0':
-    resolution: {integrity: sha512-a2U4GwMjuNnaUuR2nMpTXXbCTMvBRj3zmKhy5wWD76hj21YF6JTFBzZ+yelLrjKrGNkq2AGqYEL7d1gX+6v+JA==}
+  '@swc/plugin-prefresh@13.0.0':
+    resolution: {integrity: sha512-H/jPol2yvZ2mgFVmc1Doo3CDiwWoBxuq2s/SZgC5U77G+eDyrNXk8nPRhOSD8xwXeptmxws/hLSsAkpk8vIJng==}
 
-  '@swc/plugin-relay@12.12.0':
-    resolution: {integrity: sha512-fEotAwhEWrEakYkwclW97U8dFZdB/bPk1KAb3TiTFEh86P75UboDAeNaFDKtVV2xy+XPixEuLee+T2gp3oVxHQ==}
+  '@swc/plugin-relay@13.0.0':
+    resolution: {integrity: sha512-nfL0+lu3Whd19zCzDcrBMYZRfQtA33XAJ/353hmYdMYZjTcijUkIqDDpLxK1xATiG3PgB9ifL0PPnuxHImaI/A==}
 
-  '@swc/plugin-remove-console@12.12.0':
-    resolution: {integrity: sha512-WDapugKqAprETYGou60sZtupefIUepGMmKutqMrQ/lLgvgc+wlzWv4t2m4Bj92GLJlbUT7/PyNFh8HsVYggWHA==}
+  '@swc/plugin-remove-console@13.0.0':
+    resolution: {integrity: sha512-rZF8EO3LVOOc1gv/KwrEtRfsI5EN655VVracPgUtWYtp/BYYn/zsqkTVXkXCOZHzC9fB/DxXEW1MuSMi4BvpSg==}
 
-  '@swc/plugin-styled-components@12.12.1':
-    resolution: {integrity: sha512-2QyISNeE501HvH9QcFOFvRMOnueWuulfJJxWadLoHtCAiTySCdWnCyLfErz2erXZUv9BDJO46/oeiiKlYiAiUQ==}
+  '@swc/plugin-styled-components@13.0.0':
+    resolution: {integrity: sha512-9kWagP4qtU4XZ7iyVrR2Nlw4/NMrbRpPCsCims15tKPHiWDI2FdL9+2ocOqB+uDwNCv3wGc8P/Eagbh3+zY/3Q==}
 
-  '@swc/plugin-styled-jsx@13.12.0':
-    resolution: {integrity: sha512-1miNCe6YTjzG1WaaS+sNNruC1M3xMfIM9rR77Iw/Sbuolm5zGRpm2cic+4z3bj+atNLhXyEdERyuRitTZBhQKQ==}
+  '@swc/plugin-styled-jsx@14.0.0':
+    resolution: {integrity: sha512-Wl6UhAxoSss+RP3AhQP36wOCIUTMPbWTiRKxG6t2Bgjqwb2xd/AuPMwS3EFprDV473hqfVGMntzIpz0iMBGnZQ==}
 
-  '@swc/plugin-transform-imports@12.12.0':
-    resolution: {integrity: sha512-HblKH6MOf2l9zV+ijHBUBlslZDJ+YIq8Vt5TFXgY44lZZFC8AaF6aWU4nvvyoVQmXKaAPX5SF4D1abcq14PSfw==}
+  '@swc/plugin-transform-imports@13.0.0':
+    resolution: {integrity: sha512-G8Wp8zX92O5F2YQ8OSqoAbNqPiU7VTLKFBtmN4W0y29SaNUDi8rLwvos5P5J1qdrQP3BmnQnS1wdZioMZXlJmw==}
 
   '@sxzz/popperjs-es@2.11.8':
     resolution: {integrity: sha512-wOwESXvvED3S8xBmcPWHs2dUuzrE4XiZeFu7e1hROIJkm02a49N120pmOXxY33sBb6hArItm5W5tcg1cBtV+HQ==}
@@ -16649,6 +16764,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.3':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.3
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -16665,6 +16786,11 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
@@ -16676,6 +16802,11 @@ snapshots:
     optional: true
 
   '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -17581,7 +17712,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.0(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)':
+  '@module-federation/enhanced@2.5.0(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/cli': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)
@@ -17590,7 +17721,7 @@ snapshots:
       '@module-federation/inject-external-runtime-core-plugin': 2.5.0(@module-federation/runtime-tools@2.5.0)
       '@module-federation/managers': 2.5.0(node-fetch@2.7.0)
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)
-      '@module-federation/rspack': 2.5.0(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)
+      '@module-federation/rspack': 2.5.0(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       '@module-federation/webpack-bundler-runtime': 2.5.0(node-fetch@2.7.0)
@@ -17665,9 +17796,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.43(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)':
+  '@module-federation/node@2.7.43(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
       '@module-federation/runtime': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
       encoding: 0.1.13
@@ -17682,13 +17813,13 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)':
+  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)':
     dependencies:
       '@module-federation/enhanced': 2.5.0(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)
       '@module-federation/node': 2.7.43(@rspack/core@2.1.4)(typescript@5.9.3)(vue-tsc@3.3.7)(webpack@5.102.1)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -17698,13 +17829,13 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)':
+  '@module-federation/rsbuild-plugin@2.5.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
-      '@module-federation/node': 2.7.43(@rspack/core@2.1.4)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
+      '@module-federation/node': 2.7.43(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -17732,7 +17863,7 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/rspack@2.5.0(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)':
+  '@module-federation/rspack@2.5.0(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.0(node-fetch@2.7.0)
       '@module-federation/dts-plugin': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)
@@ -17741,7 +17872,7 @@ snapshots:
       '@module-federation/manifest': 2.5.0(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     optionalDependencies:
       typescript: 6.0.3
       vue-tsc: 3.3.7(typescript@6.0.3)
@@ -17794,13 +17925,13 @@ snapshots:
     optionalDependencies:
       node-fetch: 2.7.0(encoding@0.1.13)
 
-  '@module-federation/storybook-addon@6.0.12(@module-federation/sdk@2.5.0)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)(webpack@5.102.1)':
+  '@module-federation/storybook-addon@6.0.12(@module-federation/sdk@2.5.0)(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(storybook@10.4.1)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack-virtual-modules@0.6.2)(webpack@5.102.1)':
     dependencies:
-      '@module-federation/enhanced': 2.5.0(@rspack/core@2.1.4)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
+      '@module-federation/enhanced': 2.5.0(@rspack/core@2.2.0-beta.1)(node-fetch@2.7.0)(typescript@6.0.3)(vue-tsc@3.3.7)(webpack@5.102.1)
     optionalDependencies:
       '@module-federation/sdk': 2.5.0(node-fetch@2.7.0)
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       webpack: 5.102.1(lightningcss@1.32.0)
       webpack-virtual-modules: 0.6.2
     transitivePeerDependencies:
@@ -17854,6 +17985,13 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -18140,9 +18278,9 @@ snapshots:
   '@oxc-resolver/binding-openharmony-arm64@11.19.1':
     optional: true
 
-  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -18487,6 +18625,15 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
+  '@rsbuild/core@2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)':
+    dependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@swc/helpers': 0.5.23
+    optionalDependencies:
+      core-js: 3.49.0
+    transitivePeerDependencies:
+      - '@module-federation/runtime-tools'
+
   '@rsbuild/plugin-babel@1.1.2(@rsbuild/core@2.1.6)':
     dependencies:
       '@babel/core': 7.29.7
@@ -18513,6 +18660,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@rsbuild/plugin-babel@1.2.1(@rsbuild/core@2.2.0-beta.1)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@types/babel__core': 7.20.5
+      reduce-configs: 1.1.2
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)':
     dependencies:
       '@babel/core': 7.29.7
@@ -18529,7 +18689,23 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.1.6)':
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
+      '@types/babel__core': 7.20.5
+      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.1.4)(webpack@5.102.1)
+      reduce-configs: 1.1.2
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - supports-color
+      - webpack
+
+  '@rsbuild/plugin-check-syntax@1.6.1(@rsbuild/core@2.2.0-beta.1)':
     dependencies:
       acorn: 8.16.0
       browserslist-to-es-version: 1.2.0
@@ -18537,14 +18713,14 @@ snapshots:
       picocolors: 1.1.1
       source-map: 0.7.6
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
-  '@rsbuild/plugin-eslint@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(eslint@9.39.4)':
+  '@rsbuild/plugin-eslint@2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(eslint@9.39.4)':
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
       eslint-rspack-plugin: 5.0.0(@rspack/core@2.1.4)(eslint@9.39.4)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -18560,11 +18736,23 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsbuild/plugin-mdx@1.1.2(@rsbuild/core@2.1.6)(webpack@5.102.1)':
+  '@rsbuild/plugin-less@1.6.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)':
+    dependencies:
+      deepmerge: 4.3.1
+      less: 4.6.4
+      less-loader: 12.3.3(@rspack/core@2.1.4)(less@4.6.4)(webpack@5.102.1)
+      reduce-configs: 1.1.2
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - webpack
+
+  '@rsbuild/plugin-mdx@1.1.2(@rsbuild/core@2.2.0-beta.1)(webpack@5.102.1)':
     dependencies:
       '@mdx-js/loader': 3.1.1(webpack@5.102.1)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - supports-color
       - webpack
@@ -18574,9 +18762,21 @@ snapshots:
       '@prefresh/core': 1.5.10(preact@10.29.2)
       '@prefresh/utils': 1.2.1
       '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.4)
-      '@swc/plugin-prefresh': 12.12.0
+      '@swc/plugin-prefresh': 13.0.0
     optionalDependencies:
       '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - preact
+
+  '@rsbuild/plugin-preact@2.0.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(preact@10.29.2)':
+    dependencies:
+      '@prefresh/core': 1.5.10(preact@10.29.2)
+      '@prefresh/utils': 1.2.1
+      '@rspack/plugin-preact-refresh': 2.0.1(@prefresh/core@1.5.10)(@prefresh/utils@1.2.1)(@rspack/core@2.1.4)
+      '@swc/plugin-prefresh': 13.0.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - preact
@@ -18596,6 +18796,24 @@ snapshots:
       react-refresh: 0.18.0
     optionalDependencies:
       '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.1.4)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+
+  '@rsbuild/plugin-react@2.1.0(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)':
+    dependencies:
+      '@rspack/plugin-react-refresh': 2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
 
@@ -18621,12 +18839,24 @@ snapshots:
       - solid-js
       - supports-color
 
-  '@rsbuild/plugin-styled-components@1.6.2(@rsbuild/core@2.1.6)':
+  '@rsbuild/plugin-solid@1.2.1(@babel/core@7.29.7)(@rsbuild/core@2.2.0-beta.1)(solid-js@1.9.13)':
     dependencies:
-      '@swc/plugin-styled-components': 12.12.1
+      '@rsbuild/plugin-babel': 1.2.1(@rsbuild/core@2.2.0-beta.1)
+      babel-preset-solid: 1.9.12(@babel/core@7.29.7)(solid-js@1.9.13)
+      solid-refresh: 0.7.8(solid-js@1.9.13)
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - solid-js
+      - supports-color
+
+  '@rsbuild/plugin-styled-components@1.6.2(@rsbuild/core@2.2.0-beta.1)':
+    dependencies:
+      '@swc/plugin-styled-components': 13.0.0
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
   '@rsbuild/plugin-svelte@2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.1.6)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)':
     dependencies:
@@ -18647,43 +18877,62 @@ snapshots:
       - sugarss
       - typescript
 
-  '@rsbuild/plugin-tailwindcss@2.0.1(@rsbuild/core@2.1.6)(webpack@5.102.1)':
+  '@rsbuild/plugin-svelte@2.0.1(@babel/core@7.29.7)(@rsbuild/core@2.2.0-beta.1)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)':
+    dependencies:
+      svelte: 5.56.0(@typescript-eslint/types@8.60.0)
+      svelte-loader: 3.2.4(svelte@5.56.0)
+      svelte-preprocess: 6.0.5(@babel/core@7.29.7)(less@4.6.4)(postcss-load-config@6.0.1)(postcss@8.5.15)(pug@3.0.2)(sass@1.100.0)(stylus@0.64.0)(svelte@5.56.0)(typescript@5.9.3)
+    optionalDependencies:
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - coffeescript
+      - less
+      - postcss
+      - postcss-load-config
+      - pug
+      - sass
+      - stylus
+      - sugarss
+      - typescript
+
+  '@rsbuild/plugin-tailwindcss@2.0.1(@rsbuild/core@2.2.0-beta.1)(webpack@5.102.1)':
     dependencies:
       '@tailwindcss/webpack': 4.3.0(webpack@5.102.1)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - webpack
 
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@5.9.3)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(typescript@5.9.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
       ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.1.4)(typescript@5.9.3)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
       - typescript
 
-  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)':
+  '@rsbuild/plugin-type-check@1.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)':
     dependencies:
       deepmerge: 4.3.1
       json5: 2.2.3
       reduce-configs: 1.1.2
-      ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.1.4)(typescript@6.0.3)
+      ts-checker-rspack-plugin: 1.3.1(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - tslib
       - typescript
 
-  '@rsbuild/plugin-umd@1.0.7(@rsbuild/core@2.1.6)':
+  '@rsbuild/plugin-umd@1.0.7(@rsbuild/core@2.2.0-beta.1)':
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
   '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)':
     dependencies:
@@ -18695,11 +18944,11 @@ snapshots:
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(vue@3.5.35)':
+  '@rsbuild/plugin-vue@2.0.1(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(vue@3.5.35)':
     dependencies:
-      rspack-vue-loader: 17.5.1(@rspack/core@2.1.4)(vue@3.5.35)
+      rspack-vue-loader: 17.5.1(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.35)(vue@3.5.35)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@vue/compiler-sfc'
@@ -18707,14 +18956,38 @@ snapshots:
 
   '@rsdoctor/client@1.5.12': {}
 
-  '@rsdoctor/core@1.5.12(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)':
+  '@rsdoctor/core@1.5.12(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)':
     dependencies:
-      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.1.6)
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.2.0-beta.1)
       '@rsdoctor/graph': 1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsdoctor/sdk': 1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsdoctor/types': 1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsdoctor/utils': 1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)
-      '@rspack/resolver': 0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@rspack/resolver': 0.2.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+      browserslist-load-config: 1.0.1
+      es-toolkit: 1.45.1
+      filesize: 11.0.17
+      fs-extra: 11.3.5
+      semver: 7.8.1
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rsbuild/core'
+      - '@rspack/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - webpack
+
+  '@rsdoctor/core@1.5.12(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)':
+    dependencies:
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.2.0-beta.1)
+      '@rsdoctor/graph': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rsdoctor/sdk': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rsdoctor/types': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rsdoctor/utils': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rspack/resolver': 0.2.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       browserslist-load-config: 1.0.1
       es-toolkit: 1.45.1
       filesize: 11.0.17
@@ -18742,15 +19015,44 @@ snapshots:
       - '@rspack/core'
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.5.12(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)':
+  '@rsdoctor/graph@1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)':
     dependencies:
-      '@rsdoctor/core': 1.5.12(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(webpack@5.102.1)
+      '@rsdoctor/types': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rsdoctor/utils': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      es-toolkit: 1.45.1
+      path-browserify: 1.0.1
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - webpack
+
+  '@rsdoctor/rspack-plugin@1.5.12(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)':
+    dependencies:
+      '@rsdoctor/core': 1.5.12(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsdoctor/graph': 1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsdoctor/sdk': 1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsdoctor/types': 1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)
       '@rsdoctor/utils': 1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)
     optionalDependencies:
       '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rsbuild/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - webpack
+
+  '@rsdoctor/rspack-plugin@1.5.12(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)':
+    dependencies:
+      '@rsdoctor/core': 1.5.12(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rsdoctor/graph': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rsdoctor/sdk': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rsdoctor/types': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rsdoctor/utils': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+    optionalDependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -18777,6 +19079,23 @@ snapshots:
       - utf-8-validate
       - webpack
 
+  '@rsdoctor/sdk@1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)':
+    dependencies:
+      '@rsdoctor/client': 1.5.12
+      '@rsdoctor/graph': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rsdoctor/types': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      '@rsdoctor/utils': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
+      launch-editor: 2.13.2
+      safer-buffer: 2.1.2
+      socket.io: 4.8.1
+      tapable: 2.3.3
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - webpack
+
   '@rsdoctor/types@1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)':
     dependencies:
       '@types/connect': 3.4.38
@@ -18787,10 +19106,41 @@ snapshots:
       '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1
 
+  '@rsdoctor/types@1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/estree': 1.0.5
+      '@types/tapable': 2.3.0
+      source-map: 0.7.6
+    optionalDependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      webpack: 5.102.1
+
   '@rsdoctor/utils@1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@rsdoctor/types': 1.5.12(@rspack/core@2.1.4)(webpack@5.102.1)
+      '@types/estree': 1.0.5
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      acorn-walk: 8.3.5
+      deep-eql: 4.1.4
+      envinfo: 7.21.0
+      fs-extra: 11.3.5
+      get-port: 5.1.1
+      json-stream-stringify: 3.0.1
+      lines-and-columns: 2.0.4
+      picocolors: 1.1.1
+      rslog: 2.1.2
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - webpack
+
+  '@rsdoctor/utils@1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@rsdoctor/types': 1.5.12(@rspack/core@2.2.0-beta.1)(webpack@5.102.1)
       '@types/estree': 1.0.5
       acorn: 8.16.0
       acorn-import-attributes: 1.9.5(acorn@8.16.0)
@@ -18881,6 +19231,9 @@ snapshots:
   '@rspack/binding-darwin-arm64@2.1.4':
     optional: true
 
+  '@rspack/binding-darwin-arm64@2.2.0-beta.1':
+    optional: true
+
   '@rspack/binding-darwin-x64@1.6.7':
     optional: true
 
@@ -18888,6 +19241,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-darwin-x64@2.1.4':
+    optional: true
+
+  '@rspack/binding-darwin-x64@2.2.0-beta.1':
     optional: true
 
   '@rspack/binding-linux-arm64-gnu@1.6.7':
@@ -18899,6 +19255,9 @@ snapshots:
   '@rspack/binding-linux-arm64-gnu@2.1.4':
     optional: true
 
+  '@rspack/binding-linux-arm64-gnu@2.2.0-beta.1':
+    optional: true
+
   '@rspack/binding-linux-arm64-musl@1.6.7':
     optional: true
 
@@ -18908,10 +19267,25 @@ snapshots:
   '@rspack/binding-linux-arm64-musl@2.1.4':
     optional: true
 
+  '@rspack/binding-linux-arm64-musl@2.2.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-ppc64-gnu@2.2.0-beta.1':
+    optional: true
+
   '@rspack/binding-linux-riscv64-gnu@2.1.4':
     optional: true
 
+  '@rspack/binding-linux-riscv64-gnu@2.2.0-beta.1':
+    optional: true
+
   '@rspack/binding-linux-riscv64-musl@2.1.4':
+    optional: true
+
+  '@rspack/binding-linux-riscv64-musl@2.2.0-beta.1':
+    optional: true
+
+  '@rspack/binding-linux-s390x-gnu@2.2.0-beta.1':
     optional: true
 
   '@rspack/binding-linux-x64-gnu@1.6.7':
@@ -18923,6 +19297,9 @@ snapshots:
   '@rspack/binding-linux-x64-gnu@2.1.4':
     optional: true
 
+  '@rspack/binding-linux-x64-gnu@2.2.0-beta.1':
+    optional: true
+
   '@rspack/binding-linux-x64-musl@1.6.7':
     optional: true
 
@@ -18930,6 +19307,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-linux-x64-musl@2.1.4':
+    optional: true
+
+  '@rspack/binding-linux-x64-musl@2.2.0-beta.1':
     optional: true
 
   '@rspack/binding-wasm32-wasi@1.6.7':
@@ -18951,6 +19331,13 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
+  '@rspack/binding-wasm32-wasi@2.2.0-beta.1':
+    dependencies:
+      '@emnapi/core': 1.11.3
+      '@emnapi/runtime': 1.11.3
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
+    optional: true
+
   '@rspack/binding-win32-arm64-msvc@1.6.7':
     optional: true
 
@@ -18958,6 +19345,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-win32-arm64-msvc@2.1.4':
+    optional: true
+
+  '@rspack/binding-win32-arm64-msvc@2.2.0-beta.1':
     optional: true
 
   '@rspack/binding-win32-ia32-msvc@1.6.7':
@@ -18969,6 +19359,9 @@ snapshots:
   '@rspack/binding-win32-ia32-msvc@2.1.4':
     optional: true
 
+  '@rspack/binding-win32-ia32-msvc@2.2.0-beta.1':
+    optional: true
+
   '@rspack/binding-win32-x64-msvc@1.6.7':
     optional: true
 
@@ -18976,6 +19369,9 @@ snapshots:
     optional: true
 
   '@rspack/binding-win32-x64-msvc@2.1.4':
+    optional: true
+
+  '@rspack/binding-win32-x64-msvc@2.2.0-beta.1':
     optional: true
 
   '@rspack/binding@1.6.7':
@@ -19019,11 +19415,28 @@ snapshots:
       '@rspack/binding-win32-ia32-msvc': 2.1.4
       '@rspack/binding-win32-x64-msvc': 2.1.4
 
-  '@rspack/cli@2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)':
-    dependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+  '@rspack/binding@2.2.0-beta.1':
     optionalDependencies:
-      '@rspack/dev-server': 2.1.0(@rspack/core@2.1.4)
+      '@rspack/binding-darwin-arm64': 2.2.0-beta.1
+      '@rspack/binding-darwin-x64': 2.2.0-beta.1
+      '@rspack/binding-linux-arm64-gnu': 2.2.0-beta.1
+      '@rspack/binding-linux-arm64-musl': 2.2.0-beta.1
+      '@rspack/binding-linux-ppc64-gnu': 2.2.0-beta.1
+      '@rspack/binding-linux-riscv64-gnu': 2.2.0-beta.1
+      '@rspack/binding-linux-riscv64-musl': 2.2.0-beta.1
+      '@rspack/binding-linux-s390x-gnu': 2.2.0-beta.1
+      '@rspack/binding-linux-x64-gnu': 2.2.0-beta.1
+      '@rspack/binding-linux-x64-musl': 2.2.0-beta.1
+      '@rspack/binding-wasm32-wasi': 2.2.0-beta.1
+      '@rspack/binding-win32-arm64-msvc': 2.2.0-beta.1
+      '@rspack/binding-win32-ia32-msvc': 2.2.0-beta.1
+      '@rspack/binding-win32-x64-msvc': 2.2.0-beta.1
+
+  '@rspack/cli@2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)':
+    dependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+    optionalDependencies:
+      '@rspack/dev-server': 2.1.0(@rspack/core@2.2.0-beta.1)
 
   '@rspack/core@1.6.7(@swc/helpers@0.5.23)':
     dependencies:
@@ -19047,14 +19460,21 @@ snapshots:
       '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
       '@swc/helpers': 0.5.23
 
-  '@rspack/dev-middleware@2.0.3(@rspack/core@2.1.4)':
-    optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
-
-  '@rspack/dev-server@2.1.0(@rspack/core@2.1.4)':
+  '@rspack/core@2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)':
     dependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
-      '@rspack/dev-middleware': 2.0.3(@rspack/core@2.1.4)
+      '@rspack/binding': 2.2.0-beta.1
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.5.0(node-fetch@2.7.0)
+      '@swc/helpers': 0.5.23
+
+  '@rspack/dev-middleware@2.0.3(@rspack/core@2.2.0-beta.1)':
+    optionalDependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+
+  '@rspack/dev-server@2.1.0(@rspack/core@2.2.0-beta.1)':
+    dependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/dev-middleware': 2.0.3(@rspack/core@2.2.0-beta.1)
 
   '@rspack/lite-tapable@1.1.0': {}
 
@@ -19082,6 +19502,12 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
+  '@rspack/plugin-react-refresh@2.0.2(@rspack/core@2.2.0-beta.1)(react-refresh@0.18.0)':
+    dependencies:
+      react-refresh: 0.18.0
+    optionalDependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+
   '@rspack/resolver-binding-darwin-arm64@0.2.8':
     optional: true
 
@@ -19100,9 +19526,9 @@ snapshots:
   '@rspack/resolver-binding-linux-x64-musl@0.2.8':
     optional: true
 
-  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@rspack/resolver-binding-wasm32-wasi@0.2.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -19117,7 +19543,7 @@ snapshots:
   '@rspack/resolver-binding-win32-x64-msvc@0.2.8':
     optional: true
 
-  '@rspack/resolver@0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
+  '@rspack/resolver@0.2.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)':
     optionalDependencies:
       '@rspack/resolver-binding-darwin-arm64': 0.2.8
       '@rspack/resolver-binding-darwin-x64': 0.2.8
@@ -19125,7 +19551,7 @@ snapshots:
       '@rspack/resolver-binding-linux-arm64-musl': 0.2.8
       '@rspack/resolver-binding-linux-x64-gnu': 0.2.8
       '@rspack/resolver-binding-linux-x64-musl': 0.2.8
-      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@rspack/resolver-binding-wasm32-wasi': 0.2.8(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@rspack/resolver-binding-win32-arm64-msvc': 0.2.8
       '@rspack/resolver-binding-win32-ia32-msvc': 0.2.8
       '@rspack/resolver-binding-win32-x64-msvc': 0.2.8
@@ -19225,9 +19651,9 @@ snapshots:
       - '@module-federation/runtime-tools'
       - core-js
 
-  '@rstest/adapter-rsbuild@0.10.3(@rsbuild/core@2.1.6)(@rstest/core@0.10.3)':
+  '@rstest/adapter-rsbuild@0.10.3(@rsbuild/core@2.2.0-beta.1)(@rstest/core@0.10.3)':
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rstest/core': 0.10.3(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(happy-dom@20.9.0)(jsdom@27.4.0)
 
   '@rstest/adapter-rslib@0.10.3(@rslib/core@0.22.0)(@rstest/core@0.10.3)(typescript@5.9.3)':
@@ -19237,10 +19663,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@rstest/adapter-rspack@0.10.3(@rspack/cli@2.1.4)(@rspack/core@2.1.4)(@rstest/core@0.10.3)':
+  '@rstest/adapter-rspack@0.10.3(@rspack/cli@2.1.4)(@rspack/core@2.2.0-beta.1)(@rstest/core@0.10.3)':
     dependencies:
-      '@rspack/cli': 2.1.4(@rspack/core@2.1.4)(@rspack/dev-server@2.1.0)
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/cli': 2.1.4(@rspack/core@2.2.0-beta.1)(@rspack/dev-server@2.1.0)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       '@rstest/core': 0.10.3(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(happy-dom@20.9.0)(jsdom@27.4.0)
 
   '@rstest/browser-react@0.10.3(@rstest/core@0.10.3)(react-dom@19.2.7)(react@19.2.7)':
@@ -19524,7 +19950,7 @@ snapshots:
       '@storybook/react-dom-shim': 10.4.1(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.2.0
     optionalDependencies:
       '@types/react': 19.2.15
@@ -19537,11 +19963,11 @@ snapshots:
 
   '@storybook/addon-onboarding@10.4.1(storybook@10.4.1)':
     dependencies:
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
 
   '@storybook/csf-plugin@10.4.1(esbuild@0.28.1)(rollup@4.60.3)(storybook@10.4.1)(vite@7.1.1)(webpack@5.102.1)':
     dependencies:
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
@@ -19588,7 +20014,7 @@ snapshots:
     dependencies:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
@@ -19601,7 +20027,7 @@ snapshots:
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
@@ -19617,7 +20043,7 @@ snapshots:
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.7(react@19.2.7)
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
@@ -19628,7 +20054,7 @@ snapshots:
   '@storybook/vue3@10.4.1(storybook@10.4.1)(vue@3.5.35)':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       type-fest: 2.19.0
       vue: 3.5.35(typescript@5.9.3)
       vue-component-type-helpers: 3.3.2
@@ -19767,35 +20193,35 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@swc/plugin-emotion@14.12.0':
+  '@swc/plugin-emotion@15.0.0':
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@swc/plugin-loadable-components@11.12.0':
+  '@swc/plugin-loadable-components@12.0.0':
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@swc/plugin-prefresh@12.12.0':
+  '@swc/plugin-prefresh@13.0.0':
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@swc/plugin-relay@12.12.0':
+  '@swc/plugin-relay@13.0.0':
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@swc/plugin-remove-console@12.12.0':
+  '@swc/plugin-remove-console@13.0.0':
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@swc/plugin-styled-components@12.12.1':
+  '@swc/plugin-styled-components@13.0.0':
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@swc/plugin-styled-jsx@13.12.0':
+  '@swc/plugin-styled-jsx@14.0.0':
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@swc/plugin-transform-imports@12.12.0':
+  '@swc/plugin-transform-imports@13.0.0':
     dependencies:
       '@swc/counter': 0.1.3
 
@@ -19964,7 +20390,7 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@tanstack/react-start-rsc@0.1.18(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)':
+  '@tanstack/react-start-rsc@0.1.18(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)':
     dependencies:
       '@tanstack/react-router': 1.170.11(react-dom@19.2.7)(react@19.2.7)
       '@tanstack/react-start-server': 1.167.14(crossws@0.4.5)(react-dom@19.2.7)(react@19.2.7)
@@ -19972,7 +20398,7 @@ snapshots:
       '@tanstack/router-utils': 1.162.1
       '@tanstack/start-client-core': 1.170.7
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.11(@rsbuild/core@2.1.6)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(vite@8.0.16)(webpack@5.102.1)
+      '@tanstack/start-plugin-core': 1.171.11(@rsbuild/core@2.2.0-beta.1)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(vite@8.0.16)(webpack@5.102.1)
       '@tanstack/start-server-core': 1.169.9(crossws@0.4.5)
       '@tanstack/start-storage-context': 1.167.11
       pathe: 2.0.3
@@ -20002,21 +20428,21 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.19(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)':
+  '@tanstack/react-start@1.168.19(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)':
     dependencies:
       '@tanstack/react-router': 1.170.11(react-dom@19.2.7)(react@19.2.7)
       '@tanstack/react-start-client': 1.168.8(react-dom@19.2.7)(react@19.2.7)
-      '@tanstack/react-start-rsc': 0.1.18(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
+      '@tanstack/react-start-rsc': 0.1.18(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(@vitejs/plugin-rsc@0.5.27)(crossws@0.4.5)(react-dom@19.2.7)(react-server-dom-rspack@0.0.2)(react@19.2.7)(vite@8.0.16)(webpack@5.102.1)
       '@tanstack/react-start-server': 1.167.14(crossws@0.4.5)(react-dom@19.2.7)(react@19.2.7)
       '@tanstack/router-utils': 1.162.1
       '@tanstack/start-client-core': 1.170.7
-      '@tanstack/start-plugin-core': 1.171.11(@rsbuild/core@2.1.6)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(vite@8.0.16)(webpack@5.102.1)
+      '@tanstack/start-plugin-core': 1.171.11(@rsbuild/core@2.2.0-beta.1)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(vite@8.0.16)(webpack@5.102.1)
       '@tanstack/start-server-core': 1.169.9(crossws@0.4.5)
       pathe: 2.0.3
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@vitejs/plugin-rsc': 0.5.27(react-dom@19.2.7)(react@19.2.7)(vite@8.0.16)
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -20062,7 +20488,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.14(@rsbuild/core@2.1.6)(@tanstack/react-router@1.170.11)(vite@8.0.16)(webpack@5.102.1)':
+  '@tanstack/router-plugin@1.168.14(@rsbuild/core@2.2.0-beta.1)(@tanstack/react-router@1.170.11)(vite@8.0.16)(webpack@5.102.1)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
@@ -20078,7 +20504,7 @@ snapshots:
       unplugin: 3.0.0
       zod: 4.4.3
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@tanstack/react-router': 1.170.11(react-dom@19.2.7)(react@19.2.7)
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.9.0)
       webpack: 5.102.1(esbuild@0.28.1)
@@ -20138,18 +20564,18 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/solid-start@1.168.19(@rsbuild/core@2.1.6)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(solid-js@1.9.13)(vite@8.0.16)(webpack@5.102.1)':
+  '@tanstack/solid-start@1.168.19(@rsbuild/core@2.2.0-beta.1)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(solid-js@1.9.13)(vite@8.0.16)(webpack@5.102.1)':
     dependencies:
       '@tanstack/solid-router': 1.170.11(solid-js@1.9.13)
       '@tanstack/solid-start-client': 1.168.8(solid-js@1.9.13)
       '@tanstack/solid-start-server': 1.167.14(crossws@0.4.5)(solid-js@1.9.13)
       '@tanstack/start-client-core': 1.170.7
-      '@tanstack/start-plugin-core': 1.171.11(@rsbuild/core@2.1.6)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(vite@8.0.16)(webpack@5.102.1)
+      '@tanstack/start-plugin-core': 1.171.11(@rsbuild/core@2.2.0-beta.1)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(vite@8.0.16)(webpack@5.102.1)
       '@tanstack/start-server-core': 1.169.9(crossws@0.4.5)
       pathe: 2.0.3
       solid-js: 1.9.13
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@tanstack/react-router'
@@ -20167,7 +20593,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.11(@rsbuild/core@2.1.6)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(vite@8.0.16)(webpack@5.102.1)':
+  '@tanstack/start-plugin-core@1.171.11(@rsbuild/core@2.2.0-beta.1)(@tanstack/react-router@1.170.11)(crossws@0.4.5)(vite@8.0.16)(webpack@5.102.1)':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7
@@ -20175,7 +20601,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       '@tanstack/router-core': 1.171.9
       '@tanstack/router-generator': 1.167.13
-      '@tanstack/router-plugin': 1.168.14(@rsbuild/core@2.1.6)(@tanstack/react-router@1.170.11)(vite@8.0.16)(webpack@5.102.1)
+      '@tanstack/router-plugin': 1.168.14(@rsbuild/core@2.2.0-beta.1)(@tanstack/react-router@1.170.11)(vite@8.0.16)(webpack@5.102.1)
       '@tanstack/router-utils': 1.162.1
       '@tanstack/start-client-core': 1.170.7
       '@tanstack/start-server-core': 1.169.9(crossws@0.4.5)
@@ -20192,7 +20618,7 @@ snapshots:
       xmlbuilder2: 4.0.3
       zod: 4.4.3
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(less@4.6.4)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.64.0)(terser@5.37.0)(tsx@4.19.2)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@tanstack/react-router'
@@ -21169,6 +21595,14 @@ snapshots:
       find-up: 5.0.0
     optionalDependencies:
       '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      webpack: 5.102.1
+
+  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.2.0-beta.1)(webpack@5.102.1):
+    dependencies:
+      '@babel/core': 7.29.7
+      find-up: 5.0.0
+    optionalDependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1(postcss@8.5.15)
 
   babel-plugin-jsx-dom-expressions@0.40.6(@babel/core@7.29.7):
@@ -21766,7 +22200,7 @@ snapshots:
   css-color-keywords@1.0.0:
     optional: true
 
-  css-loader@7.1.4(@rspack/core@2.1.4)(webpack@5.102.1):
+  css-loader@7.1.4(@rspack/core@2.2.0-beta.1)(webpack@5.102.1):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -21777,7 +22211,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.1
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1(postcss@8.5.15)
 
   css-mediaquery@0.1.2: {}
@@ -22438,14 +22872,14 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
-  eslint-rspack-plugin@5.0.1(@rspack/core@2.1.4)(eslint@9.39.4):
+  eslint-rspack-plugin@5.0.1(@rspack/core@2.2.0-beta.1)(eslint@9.39.4):
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
       micromatch: 4.0.8
       normalize-path: 3.0.0
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -23378,7 +23812,7 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.7(@rspack/core@2.1.4)(webpack@5.102.1):
+  html-webpack-plugin@5.6.7(@rspack/core@2.2.0-beta.1)(webpack@5.102.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -23386,7 +23820,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1
 
   htmlparser2@10.0.0:
@@ -23935,6 +24369,13 @@ snapshots:
       less: 4.6.4
     optionalDependencies:
       '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      webpack: 5.102.1
+
+  less-loader@12.3.3(@rspack/core@2.2.0-beta.1)(less@4.6.4)(webpack@5.102.1):
+    dependencies:
+      less: 4.6.4
+    optionalDependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1(postcss@8.5.15)
 
   less@4.6.4:
@@ -25427,7 +25868,7 @@ snapshots:
       '@oxc-parser/binding-win32-ia32-msvc': 0.127.0
       '@oxc-parser/binding-win32-x64-msvc': 0.127.0
 
-  oxc-resolver@11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2):
+  oxc-resolver@11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3):
     optionalDependencies:
       '@oxc-resolver/binding-android-arm-eabi': 11.19.1
       '@oxc-resolver/binding-android-arm64': 11.19.1
@@ -25445,7 +25886,7 @@ snapshots:
       '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
       '@oxc-resolver/binding-linux-x64-musl': 11.19.1
       '@oxc-resolver/binding-openharmony-arm64': 11.19.1
-      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
       '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
       '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
@@ -25727,14 +26168,14 @@ snapshots:
       tsx: 4.19.2
       yaml: 2.9.0
 
-  postcss-loader@8.2.1(@rspack/core@2.1.4)(postcss@8.5.15)(typescript@6.0.3)(webpack@5.102.1):
+  postcss-loader@8.2.1(@rspack/core@2.2.0-beta.1)(postcss@8.5.15)(typescript@6.0.3)(webpack@5.102.1):
     dependencies:
       cosmiconfig: 9.0.0(typescript@6.0.3)
       jiti: 2.7.0
       postcss: 8.5.15
       semver: 7.8.1
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1(postcss@8.5.15)
     transitivePeerDependencies:
       - typescript
@@ -26098,6 +26539,13 @@ snapshots:
   react-server-dom-rspack@0.0.2(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7):
     dependencies:
       '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optional: true
+
+  react-server-dom-rspack@0.0.2(@rspack/core@2.2.0-beta.1)(react-dom@19.2.7)(react@19.2.7):
+    dependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
@@ -26531,22 +26979,22 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.1.6):
+  rsbuild-plugin-html-minifier-terser@1.1.3(@rsbuild/core@2.2.0-beta.1):
     dependencies:
       '@types/html-minifier-terser': 7.0.2
       html-minifier-terser: 7.2.0
     optionalDependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
 
   rsc-html-stream@0.0.7: {}
 
   rslog@2.1.2: {}
 
-  rspack-manifest-plugin@5.2.1(@rspack/core@2.1.4):
+  rspack-manifest-plugin@5.2.1(@rspack/core@2.2.0-beta.1):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
 
   rspack-vue-loader@17.5.1(@rspack/core@2.1.4)(@vue/compiler-sfc@3.5.35)(vue@3.5.35):
     dependencies:
@@ -26557,12 +27005,12 @@ snapshots:
       '@vue/compiler-sfc': 3.5.35
       vue: 3.5.35(typescript@5.9.3)
 
-  rspack-vue-loader@17.5.1(@rspack/core@2.1.4)(vue@3.5.35):
+  rspack-vue-loader@17.5.1(@rspack/core@2.2.0-beta.1)(vue@3.5.35):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       vue: 3.5.35(typescript@6.0.3)
 
   run-applescript@7.0.0: {}
@@ -26688,11 +27136,11 @@ snapshots:
       sass-embedded-win32-arm64: 1.100.0
       sass-embedded-win32-x64: 1.100.0
 
-  sass-loader@16.0.8(@rspack/core@2.1.4)(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.102.1):
+  sass-loader@16.0.8(@rspack/core@2.2.0-beta.1)(sass-embedded@1.100.0)(sass@1.100.0)(webpack@5.102.1):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       sass: 1.100.0
       sass-embedded: 1.100.0
       webpack: 5.102.1
@@ -27072,26 +27520,26 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.6)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@5.9.3):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.2.0-beta.1)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@5.9.3):
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rslib/core': 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@5.9.3)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
     optionalDependencies:
       typescript: 5.9.3
 
-  storybook-addon-rslib@3.3.4(@rsbuild/core@2.1.6)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
+  storybook-addon-rslib@3.3.4(@rsbuild/core@2.2.0-beta.1)(@rslib/core@0.22.0)(storybook-builder-rsbuild@3.3.4)(typescript@6.0.3):
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@rslib/core': 0.22.0(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)(typescript@6.0.3)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)
     optionalDependencies:
       typescript: 6.0.3
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1):
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@5.9.3)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(typescript@5.9.3)
       '@vitest/mocker': 3.2.4(vite@7.1.1)
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -27103,9 +27551,9 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.1.6)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.2.0-beta.1)
       sirv: 2.0.4
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
@@ -27120,10 +27568,10 @@ snapshots:
       - tslib
       - vite
 
-  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1):
+  storybook-builder-rsbuild@3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1):
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
-      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(typescript@6.0.3)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/plugin-type-check': 1.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(typescript@6.0.3)
       '@vitest/mocker': 3.2.4(vite@7.1.1)
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -27135,9 +27583,9 @@ snapshots:
       path-browserify: 1.0.1
       picocolors: 1.1.1
       process: 0.11.10
-      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.1.6)
+      rsbuild-plugin-html-minifier-terser: 1.1.3(@rsbuild/core@2.2.0-beta.1)
       sirv: 2.0.4
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
@@ -27152,10 +27600,10 @@ snapshots:
       - tslib
       - vite
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.3)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(webpack@5.102.1):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.3)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(webpack@5.102.1):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@storybook/react': 10.4.1(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@5.9.3)(webpack@5.102.1)
       find-up: 5.0.0
@@ -27165,8 +27613,8 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -27181,10 +27629,10 @@ snapshots:
       - vite
       - webpack
 
-  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.3)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)(webpack@5.102.1):
+  storybook-react-rsbuild@3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(rollup@4.60.3)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)(webpack@5.102.1):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.60.3)
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@storybook/react': 10.4.1(@types/react-dom@19.2.3)(@types/react@19.2.15)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@6.0.3)
       '@storybook/react-docgen-typescript-plugin': 1.0.1(typescript@6.0.3)(webpack@5.102.1)
       find-up: 5.0.0
@@ -27194,8 +27642,8 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
       react-dom: 19.2.7(react@19.2.7)
       resolve: 1.22.12
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.2.0-beta.1)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@6.0.3)(vite@7.1.1)
       tsconfig-paths: 4.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -27210,12 +27658,12 @@ snapshots:
       - vite
       - webpack
 
-  storybook-vue3-rsbuild@3.3.4(@babel/preset-env@7.29.7)(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(vue@3.5.35)(webpack@5.102.1):
+  storybook-vue3-rsbuild@3.3.4(@babel/preset-env@7.29.7)(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)(vue@3.5.35)(webpack@5.102.1):
     dependencies:
-      '@rsbuild/core': 2.1.6(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
+      '@rsbuild/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(core-js@3.49.0)
       '@storybook/vue3': 10.4.1(storybook@10.4.1)(vue@3.5.35)
-      storybook: 10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
-      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.1.6)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
+      storybook: 10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7)
+      storybook-builder-rsbuild: 3.3.4(@rsbuild/core@2.2.0-beta.1)(@rspack/core@2.1.4)(react-dom@19.2.7)(react@19.2.7)(storybook@10.4.1)(typescript@5.9.3)(vite@7.1.1)
       vue: 3.5.35(typescript@5.9.3)
       vue-docgen-api: 4.79.2(vue@3.5.35)
       vue-docgen-loader: 2.0.1(@babel/preset-env@7.29.7)(vue-docgen-api@4.79.2)(webpack@5.102.1)
@@ -27231,7 +27679,7 @@ snapshots:
       - vite
       - webpack
 
-  storybook@10.4.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7):
+  storybook@10.4.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)(@testing-library/dom@10.4.1)(@types/react@19.2.15)(prettier@3.8.3)(react-dom@19.2.7)(react@19.2.7):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@19.2.7)(react@19.2.7)
@@ -27243,7 +27691,7 @@ snapshots:
       esbuild: 0.27.0
       open: 10.2.0
       oxc-parser: 0.127.0
-      oxc-resolver: 11.19.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
+      oxc-resolver: 11.19.1(@emnapi/core@1.11.3)(@emnapi/runtime@1.11.3)
       recast: 0.23.11
       semver: 7.8.1
       use-sync-external-store: 1.6.0(react@19.2.7)
@@ -27394,13 +27842,13 @@ snapshots:
 
   stylis@4.3.6: {}
 
-  stylus-loader@8.1.3(@rspack/core@2.1.4)(stylus@0.64.0)(webpack@5.102.1):
+  stylus-loader@8.1.3(@rspack/core@2.2.0-beta.1)(stylus@0.64.0)(webpack@5.102.1):
     dependencies:
       fast-glob: 3.3.2
       normalize-path: 3.0.0
       stylus: 0.64.0
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1(postcss@8.5.15)
 
   stylus@0.64.0:
@@ -27781,18 +28229,6 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.1.4)(tslib@2.8.1)(typescript@5.9.3):
-    dependencies:
-      '@rspack/lite-tapable': 1.1.0
-      chokidar: 3.6.0
-      memfs: 4.57.2(tslib@2.8.1)
-      picocolors: 1.1.1
-      typescript: 5.9.3
-    optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
-    transitivePeerDependencies:
-      - tslib
-
   ts-checker-rspack-plugin@1.3.1(@rspack/core@2.1.4)(typescript@5.9.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
@@ -27805,7 +28241,19 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.1.4)(typescript@6.0.3):
+  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.2.0-beta.1)(tslib@2.8.1)(typescript@5.9.3):
+    dependencies:
+      '@rspack/lite-tapable': 1.1.0
+      chokidar: 3.6.0
+      memfs: 4.57.2(tslib@2.8.1)
+      picocolors: 1.1.1
+      typescript: 5.9.3
+    optionalDependencies:
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+    transitivePeerDependencies:
+      - tslib
+
+  ts-checker-rspack-plugin@1.3.1(@rspack/core@2.2.0-beta.1)(typescript@6.0.3):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chokidar: 3.6.0
@@ -27813,7 +28261,7 @@ snapshots:
       picocolors: 1.1.1
       typescript: 6.0.3
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
     transitivePeerDependencies:
       - tslib
 
@@ -28707,12 +29155,12 @@ snapshots:
       assert-never: 1.4.0
       babel-walk: 3.0.0-canary-5
 
-  worker-rspack-loader@3.1.4(@rspack/core@2.1.4)(webpack@5.102.1):
+  worker-rspack-loader@3.1.4(@rspack/core@2.2.0-beta.1)(webpack@5.102.1):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
     optionalDependencies:
-      '@rspack/core': 2.1.4(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
+      '@rspack/core': 2.2.0-beta.1(@module-federation/runtime-tools@2.5.0)(@swc/helpers@0.5.23)
       webpack: 5.102.1
 
   wrap-ansi@7.0.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,7 @@ packages:
   - '!**/dist'
 
 dedupePeers: true
+
+overrides:
+  '@swc/plugin-prefresh': 13.0.0
+  '@swc/plugin-styled-components': 13.0.0

--- a/rsbuild/emotion/package.json
+++ b/rsbuild/emotion/package.json
@@ -14,9 +14,9 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
-    "@swc/plugin-emotion": "^14.12.0",
+    "@swc/plugin-emotion": "^15.0.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",

--- a/rsbuild/express/package.json
+++ b/rsbuild/express/package.json
@@ -9,7 +9,7 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@types/express": "^5.0.6",
     "@types/node": "^24.12.4",
     "express": "^5.2.1",

--- a/rsbuild/fastify/package.json
+++ b/rsbuild/fastify/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@fastify/middie": "^9.3.2",
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@types/node": "^24.12.4",
     "fastify": "^5.8.5",
     "typescript": "^5.9.3"

--- a/rsbuild/lit/package.json
+++ b/rsbuild/lit/package.json
@@ -9,7 +9,7 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@types/node": "^24.12.4",
     "lit": "^3.3.3",
     "typescript": "^5.9.3"

--- a/rsbuild/module-federation-enhanced/consumer/package.json
+++ b/rsbuild/module-federation-enhanced/consumer/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.0",
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rsbuild/module-federation-enhanced/provider/package.json
+++ b/rsbuild/module-federation-enhanced/provider/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.0",
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rsbuild/module-federation/host/package.json
+++ b/rsbuild/module-federation/host/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "typescript": "^5.9.3"

--- a/rsbuild/module-federation/remote/package.json
+++ b/rsbuild/module-federation/remote/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "typescript": "^5.9.3"

--- a/rsbuild/preact/package.json
+++ b/rsbuild/preact/package.json
@@ -12,7 +12,7 @@
     "preact": "^10.29.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-preact": "^2.0.0",
     "@types/node": "^24.12.4",
     "typescript": "^5.9.3"

--- a/rsbuild/query-raw/package.json
+++ b/rsbuild/query-raw/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rsbuild/react-compiler-babel/package.json
+++ b/rsbuild/react-compiler-babel/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-babel": "^2.0.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",

--- a/rsbuild/react-eslint/package.json
+++ b/rsbuild/react-eslint/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-eslint": "^2.0.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",

--- a/rsbuild/react-mdx/package.json
+++ b/rsbuild/react-mdx/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-mdx": "^1.1.2",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",

--- a/rsbuild/react-tailwindcss/package.json
+++ b/rsbuild/react-tailwindcss/package.json
@@ -14,7 +14,7 @@
     "tailwindcss": "^4.3.0"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-tailwindcss": "^2.0.1",
     "@types/node": "^24.12.4",

--- a/rsbuild/react-unocss/package.json
+++ b/rsbuild/react-unocss/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rsbuild/react/package.json
+++ b/rsbuild/react/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rsbuild/shadcn-ui/package.json
+++ b/rsbuild/shadcn-ui/package.json
@@ -19,7 +19,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rsbuild/solid/package.json
+++ b/rsbuild/solid/package.json
@@ -12,7 +12,7 @@
     "solid-js": "^1.9.13"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-babel": "^2.0.1",
     "@rsbuild/plugin-solid": "^1.2.1",
     "@types/node": "^24.12.4",

--- a/rsbuild/ssr-express-with-manifest/package.json
+++ b/rsbuild/ssr-express-with-manifest/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "2.1.0",
     "@types/express": "^5.0.6",
     "@types/node": "^24.12.4",

--- a/rsbuild/ssr-express/package.json
+++ b/rsbuild/ssr-express/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "2.1.0",
     "@types/express": "^5.0.6",
     "@types/node": "^24.12.4",

--- a/rsbuild/ssr/package.json
+++ b/rsbuild/ssr/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rsbuild/styled-components/package.json
+++ b/rsbuild/styled-components/package.json
@@ -14,7 +14,7 @@
     "styled-components": "^6.4.2"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-styled-components": "^1.6.2",
     "@types/node": "^24.12.4",

--- a/rsbuild/styled-jsx/package.json
+++ b/rsbuild/styled-jsx/package.json
@@ -14,9 +14,9 @@
     "styled-jsx": "^5.1.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
-    "@swc/plugin-styled-jsx": "^13.12.0",
+    "@swc/plugin-styled-jsx": "^14.0.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",

--- a/rsbuild/stylex/package.json
+++ b/rsbuild/stylex/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rsbuild/svelte/package.json
+++ b/rsbuild/svelte/package.json
@@ -12,7 +12,7 @@
     "svelte": "^5.56.0"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-svelte": "^2.0.1",
     "@types/node": "^24.12.4",
     "typescript": "^5.9.3"

--- a/rsbuild/tanstack-start-rsc/package.json
+++ b/rsbuild/tanstack-start-rsc/package.json
@@ -19,7 +19,7 @@
     "zustand": "^5.0.10"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.1.6",
+    "@rsbuild/core": "^2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-tailwindcss": "^2.0.1",
     "@types/node": "^24.12.4",

--- a/rsbuild/tanstack-start-solid/package.json
+++ b/rsbuild/tanstack-start-solid/package.json
@@ -17,7 +17,7 @@
     "tailwindcss": "^4.3.0"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.1.6",
+    "@rsbuild/core": "^2.2.0-beta.1",
     "@rsbuild/plugin-babel": "^2.0.1",
     "@rsbuild/plugin-solid": "^1.2.1",
     "@rsbuild/plugin-tailwindcss": "^2.0.1",

--- a/rsbuild/tanstack-start/package.json
+++ b/rsbuild/tanstack-start/package.json
@@ -22,7 +22,7 @@
     "tailwindcss": "^4.3.0"
   },
   "devDependencies": {
-    "@rsbuild/core": "^2.1.6",
+    "@rsbuild/core": "^2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsbuild/plugin-tailwindcss": "^2.0.1",
     "@tailwindcss/typography": "^0.5.19",

--- a/rsbuild/umd/package.json
+++ b/rsbuild/umd/package.json
@@ -9,7 +9,7 @@
     "preview": "rsbuild preview"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-umd": "^1.0.7",
     "@types/node": "^24.12.4",
     "typescript": "^5.9.3"

--- a/rsbuild/vanilla-extract/package.json
+++ b/rsbuild/vanilla-extract/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rsbuild/vue-auto-import/package.json
+++ b/rsbuild/vue-auto-import/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.5.35"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@types/node": "^24.12.4",
     "typescript": "^5.9.3",

--- a/rsbuild/vue-element-plus/package.json
+++ b/rsbuild/vue-element-plus/package.json
@@ -13,7 +13,7 @@
     "vue": "^3.5.35"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@types/node": "^24.12.4",
     "typescript": "^5.9.3",

--- a/rsbuild/vue-eslint/package.json
+++ b/rsbuild/vue-eslint/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.5.35"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-eslint": "^2.0.1",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@types/node": "^24.12.4",

--- a/rsbuild/vue-vant/package.json
+++ b/rsbuild/vue-vant/package.json
@@ -13,7 +13,7 @@
     "vue": "^3.5.35"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-less": "^1.6.4",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@types/node": "^24.12.4",

--- a/rsbuild/vue/package.json
+++ b/rsbuild/vue/package.json
@@ -12,7 +12,7 @@
     "vue": "^3.5.35"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@types/node": "^24.12.4",
     "typescript": "^5.9.3",

--- a/rsdoctor/rsbuild/package.json
+++ b/rsdoctor/rsbuild/package.json
@@ -15,7 +15,7 @@
     "semver7": "npm:semver@7.8.1"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rsdoctor/rspack-plugin": "^1.5.12",
     "@types/node": "^24.12.4",

--- a/rsdoctor/rspack/package.json
+++ b/rsdoctor/rspack/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@rsdoctor/rspack-plugin": "^1.5.12",
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "@types/node": "^24.12.4",

--- a/rslib/module-federation/mf-host/package.json
+++ b/rslib/module-federation/mf-host/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.0",
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rslib/module-federation/mf-remote/package.json
+++ b/rslib/module-federation/mf-remote/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@module-federation/rsbuild-plugin": "^2.5.0",
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rslib/react-storybook/package.json
+++ b/rslib/react-storybook/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rslib/core": "^0.22.0",
     "@storybook/addon-docs": "^10.4.1",

--- a/rslib/vue-storybook/package.json
+++ b/rslib/vue-storybook/package.json
@@ -19,7 +19,7 @@
     "storybook": "storybook dev"
   },
   "devDependencies": {
-    "@rsbuild/core": "~2.1.6",
+    "@rsbuild/core": "~2.2.0-beta.1",
     "@rsbuild/plugin-vue": "^2.0.1",
     "@rslib/core": "^0.22.0",
     "@storybook/addon-docs": "^10.4.1",

--- a/rspack/basic-ts-config/package.json
+++ b/rspack/basic-ts-config/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@types/node": "^24.12.4",
     "typescript": "^5.9.3"

--- a/rspack/basic-ts/package.json
+++ b/rspack/basic-ts/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@types/node": "^24.12.4"
   }

--- a/rspack/basic/package.json
+++ b/rspack/basic/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/builtin-swc-loader/package.json
+++ b/rspack/builtin-swc-loader/package.json
@@ -15,16 +15,16 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@swc/helpers": "^0.5.23",
-    "@swc/plugin-emotion": "^14.12.0",
-    "@swc/plugin-loadable-components": "^11.12.0",
-    "@swc/plugin-prefresh": "^12.12.0",
-    "@swc/plugin-relay": "^12.12.0",
-    "@swc/plugin-remove-console": "^12.12.0",
-    "@swc/plugin-styled-components": "^12.12.1",
-    "@swc/plugin-styled-jsx": "^13.12.0",
-    "@swc/plugin-transform-imports": "^12.12.0"
+    "@swc/plugin-emotion": "^15.0.0",
+    "@swc/plugin-loadable-components": "^12.0.0",
+    "@swc/plugin-prefresh": "^13.0.0",
+    "@swc/plugin-relay": "^13.0.0",
+    "@swc/plugin-remove-console": "^13.0.0",
+    "@swc/plugin-styled-components": "^13.0.0",
+    "@swc/plugin-styled-jsx": "^14.0.0",
+    "@swc/plugin-transform-imports": "^13.0.0"
   }
 }

--- a/rspack/bundle-splitting/package.json
+++ b/rspack/bundle-splitting/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/case-sensitive-paths-webpack-plugin/package.json
+++ b/rspack/case-sensitive-paths-webpack-plugin/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "case-sensitive-paths-webpack-plugin": "2.4.0"
   }

--- a/rspack/code-splitting/package.json
+++ b/rspack/code-splitting/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/cra-ts/package.json
+++ b/rspack/cra-ts/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "@types/react": "^19.2.15",

--- a/rspack/cra/package.json
+++ b/rspack/cra/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "react-refresh": "^0.18.0",

--- a/rspack/css-chunking-plugin/package.json
+++ b/rspack/css-chunking-plugin/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/css-parser-generator-options/package.json
+++ b/rspack/css-parser-generator-options/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "sass-loader": "^16.0.8"
   }

--- a/rspack/dll-reference/package.json
+++ b/rspack/dll-reference/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "lodash": "4.18.1",
     "typescript": "^5.9.3"

--- a/rspack/dll/package.json
+++ b/rspack/dll/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "typescript": "^5.9.3"
   }

--- a/rspack/emotion/package.json
+++ b/rspack/emotion/package.json
@@ -15,8 +15,8 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
-    "@swc/plugin-emotion": "^14.12.0"
+    "@swc/plugin-emotion": "^15.0.0"
   }
 }

--- a/rspack/eslint/package.json
+++ b/rspack/eslint/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "eslint": "^9.39.4",
     "eslint-rspack-plugin": "^5.0.1"

--- a/rspack/express/package.json
+++ b/rspack/express/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@types/express": "^5.0.6",
     "run-script-webpack-plugin": "0.2.3"

--- a/rspack/extract-license/package.json
+++ b/rspack/extract-license/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/generate-package-json-webpack-plugin/package.json
+++ b/rspack/generate-package-json-webpack-plugin/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "generate-package-json-webpack-plugin": "^2.7.0"
   }

--- a/rspack/hooks-after-resolve/package.json
+++ b/rspack/hooks-after-resolve/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/html-webpack-plugin/package.json
+++ b/rspack/html-webpack-plugin/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "html-webpack-plugin": "^5.6.7"
   },

--- a/rspack/http-import/package.json
+++ b/rspack/http-import/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/inline-const-enum/package.json
+++ b/rspack/inline-const-enum/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/inline-const/package.json
+++ b/rspack/inline-const/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/inline-enum/package.json
+++ b/rspack/inline-enum/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/javascript-api/package.json
+++ b/rspack/javascript-api/package.json
@@ -8,7 +8,7 @@
     "build": "tsc"
   },
   "devDependencies": {
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@types/node": "^24.12.4",
     "typescript": "^5.9.3"
   }

--- a/rspack/lazy-compilation-server/package.json
+++ b/rspack/lazy-compilation-server/package.json
@@ -6,7 +6,7 @@
     "dev": "node ./dev.js"
   },
   "devDependencies": {
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/library-cjs/package.json
+++ b/rspack/library-cjs/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/library-esm/package.json
+++ b/rspack/library-esm/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/library-umd/package.json
+++ b/rspack/library-umd/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/license-webpack-plugin/package.json
+++ b/rspack/license-webpack-plugin/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "license-webpack-plugin": "^4.0.2",
     "react": "^19.2.7",

--- a/rspack/lightingcss-loader/package.json
+++ b/rspack/lightingcss-loader/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/loader-compat/package.json
+++ b/rspack/loader-compat/package.json
@@ -15,7 +15,7 @@
     "@babel/preset-env": "7.29.7",
     "@mdx-js/loader": "3.1.1",
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@svgr/webpack": "8.1.0",
     "autoprefixer": "10.5.0",

--- a/rspack/module-federation-v1.5/app/package.json
+++ b/rspack/module-federation-v1.5/app/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "html-webpack-plugin": "^5.6.7",

--- a/rspack/module-federation-v1.5/lib1/package.json
+++ b/rspack/module-federation-v1.5/lib1/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "html-webpack-plugin": "^5.6.7",

--- a/rspack/module-federation-v1.5/lib2/package.json
+++ b/rspack/module-federation-v1.5/lib2/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "react-refresh": "^0.18.0",

--- a/rspack/module-federation-v1/app/package.json
+++ b/rspack/module-federation-v1/app/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "html-webpack-plugin": "^5.6.7",

--- a/rspack/module-federation-v1/lib1/package.json
+++ b/rspack/module-federation-v1/lib1/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "html-webpack-plugin": "^5.6.7",

--- a/rspack/module-federation-v1/lib2/package.json
+++ b/rspack/module-federation-v1/lib2/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "react-refresh": "^0.18.0",

--- a/rspack/monaco-editor-js/package.json
+++ b/rspack/monaco-editor-js/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/monaco-editor-ts-react/package.json
+++ b/rspack/monaco-editor-ts-react/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rspack/monaco-editor-webpack-plugin/package.json
+++ b/rspack/monaco-editor-webpack-plugin/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "monaco-editor": "^0.55.1",
     "monaco-editor-webpack-plugin": "^7.1.1"

--- a/rspack/multi-entry/package.json
+++ b/rspack/multi-entry/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/nest-alias/package.json
+++ b/rspack/nest-alias/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "lib1": "workspace:*",
     "lib2": "workspace:*",

--- a/rspack/nestjs/package.json
+++ b/rspack/nestjs/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@types/node": "^24.12.4",
     "cross-env": "10.1.0",

--- a/rspack/node-globals-shim/package.json
+++ b/rspack/node-globals-shim/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/node-polyfill/package.json
+++ b/rspack/node-polyfill/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "node-polyfill-webpack-plugin": "^4.1.0"
   }

--- a/rspack/perfsee/package.json
+++ b/rspack/perfsee/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "@perfsee/webpack": "1.14.2",
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/polyfill/package.json
+++ b/rspack/polyfill/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/postcss-loader/package.json
+++ b/rspack/postcss-loader/package.json
@@ -11,7 +11,7 @@
   "browserslist": "last 4 version",
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "autoprefixer": "10.5.0",
     "postcss-loader": "8.2.1",

--- a/rspack/preact-refresh/package.json
+++ b/rspack/preact-refresh/package.json
@@ -16,10 +16,10 @@
     "@prefresh/core": "1.5.10",
     "@prefresh/utils": "1.2.1",
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-preact-refresh": "^1.1.6",
-    "@swc/plugin-prefresh": "^12.12.0"
+    "@swc/plugin-prefresh": "^13.0.0"
   },
   "resolve": {
     "alias": {

--- a/rspack/preact/package.json
+++ b/rspack/preact/package.json
@@ -16,7 +16,7 @@
     "@prefresh/babel-plugin": "0.5.3",
     "@prefresh/webpack": "4.0.6",
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   },
   "resolve": {

--- a/rspack/proxy/package.json
+++ b/rspack/proxy/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/react-compiler-babel-ts/package.json
+++ b/rspack/react-compiler-babel-ts/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-syntax-jsx": "^7.29.7",
     "@babel/plugin-syntax-typescript": "^7.29.7",
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",

--- a/rspack/react-compiler-babel/package.json
+++ b/rspack/react-compiler-babel/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@babel/plugin-syntax-jsx": "^7.29.7",
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "babel-loader": "^10.1.1",
     "babel-plugin-react-compiler": "^1.0.0"

--- a/rspack/react-refresh-babel-loader/package.json
+++ b/rspack/react-refresh-babel-loader/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-react": "^7.29.7",
     "@babel/preset-typescript": "^7.29.7",
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "@types/react": "^19.2.15",

--- a/rspack/react-refresh-esm/package.json
+++ b/rspack/react-refresh-esm/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "@types/react": "^19.2.15",

--- a/rspack/react-refresh/package.json
+++ b/rspack/react-refresh/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "@types/react": "^19.2.15",

--- a/rspack/react-ssr-esm/package.json
+++ b/rspack/react-ssr-esm/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@types/cross-spawn": "^6.0.6",
     "@types/express": "^5.0.6",

--- a/rspack/react-with-extract-css/package.json
+++ b/rspack/react-with-extract-css/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "react-refresh": "^0.18.0"
   }

--- a/rspack/react-with-less/package.json
+++ b/rspack/react-with-less/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "react-refresh": "^0.18.0"
   }

--- a/rspack/react-with-sass/package.json
+++ b/rspack/react-with-sass/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "react-refresh": "^0.18.0"
   }

--- a/rspack/react/package.json
+++ b/rspack/react/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/rspack-manifest-plugin/package.json
+++ b/rspack/rspack-manifest-plugin/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "rspack-manifest-plugin": "5.2.1"
   }

--- a/rspack/rspack-rsc/package.json
+++ b/rspack/rspack-rsc/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "@types/express": "^5.0.6",

--- a/rspack/sentry/package.json
+++ b/rspack/sentry/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@sentry/webpack-plugin": "5.3.0"
   }

--- a/rspack/solid/package.json
+++ b/rspack/solid/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/source-map-with-vscode-debugging/package.json
+++ b/rspack/source-map-with-vscode-debugging/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/stats/package.json
+++ b/rspack/stats/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/styled-components/package.json
+++ b/rspack/styled-components/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",

--- a/rspack/svelte/package.json
+++ b/rspack/svelte/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@tsconfig/svelte": "^5.0.8",
     "@types/node": "^24.12.4",

--- a/rspack/svgr/package.json
+++ b/rspack/svgr/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@svgr/webpack": "8.1.0",
     "url-loader": "4.1.1"

--- a/rspack/tailwindcss-postcss/package.json
+++ b/rspack/tailwindcss-postcss/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@tailwindcss/postcss": "^4.3.0",
     "autoprefixer": "10.5.0",

--- a/rspack/tailwindcss-with-type-css/package.json
+++ b/rspack/tailwindcss-with-type-css/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@tailwindcss/webpack": "^4.3.0",
     "tailwindcss": "^4.3.0"

--- a/rspack/tailwindcss/package.json
+++ b/rspack/tailwindcss/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@tailwindcss/webpack": "^4.3.0",
     "css-loader": "^7.1.4",

--- a/rspack/terser-webpack-plugin/package.json
+++ b/rspack/terser-webpack-plugin/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "terser-webpack-plugin": "5.6.1",
     "webpack-stats-plugin": "^1.1.3"

--- a/rspack/treeshaking-transform-imports/package.json
+++ b/rspack/treeshaking-transform-imports/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/ts-checker-rspack-plugin/package.json
+++ b/rspack/ts-checker-rspack-plugin/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@types/node": "^24.12.4",
     "ts-checker-rspack-plugin": "^1.3.1",

--- a/rspack/type-reexports-presence/package.json
+++ b/rspack/type-reexports-presence/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/unplugin-auto-import/package.json
+++ b/rspack/unplugin-auto-import/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "html-webpack-plugin": "5.6.7",
     "rspack-vue-loader": "^17.5.1",

--- a/rspack/vanilla-extract-css/package.json
+++ b/rspack/vanilla-extract-css/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@vanilla-extract/css": "1.20.1",
     "@vanilla-extract/sprinkles": "^1.6.5",

--- a/rspack/vue-jsx/package.json
+++ b/rspack/vue-jsx/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@babel/core": "7.29.7",
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@vue/babel-plugin-jsx": "2.0.1",
     "babel-loader": "10.1.1"

--- a/rspack/vue-tsx/package.json
+++ b/rspack/vue-tsx/package.json
@@ -14,7 +14,7 @@
     "@babel/core": "7.29.7",
     "@babel/preset-typescript": "^7.29.7",
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@types/node": "^24.12.4",
     "@vue/babel-plugin-jsx": "2.0.1",

--- a/rspack/vue-vanilla/package.json
+++ b/rspack/vue-vanilla/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "css-loader": "^7.1.4",
     "less": "4.6.4",

--- a/rspack/vue/package.json
+++ b/rspack/vue/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "less": "4.6.4",
     "less-loader": "^12.3.3",

--- a/rspack/wasm-simple/package.json
+++ b/rspack/wasm-simple/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/webpack-bundle-analyzer/package.json
+++ b/rspack/webpack-bundle-analyzer/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "webpack-bundle-analyzer": "^5.3.0"
   }

--- a/rspack/webpack-stats-plugin/package.json
+++ b/rspack/webpack-stats-plugin/package.json
@@ -7,7 +7,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "webpack-stats-plugin": "^1.1.3"
   }

--- a/rspack/worker-inline/package.json
+++ b/rspack/worker-inline/package.json
@@ -13,7 +13,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0"
   }
 }

--- a/rspack/worker/package.json
+++ b/rspack/worker/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "remote-web-worker": "0.0.9"
   }

--- a/rspack/worklet/package.json
+++ b/rspack/worklet/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "esbuild": "0.28.1"
   }

--- a/rstest/browser-locator/package.json
+++ b/rstest/browser-locator/package.json
@@ -10,7 +10,7 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rstest/adapter-rsbuild": "^0.10.3",
     "@rstest/browser": "^0.10.3",

--- a/rstest/browser-rsbuild-react/package.json
+++ b/rstest/browser-rsbuild-react/package.json
@@ -10,7 +10,7 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rstest/adapter-rsbuild": "^0.10.3",
     "@rstest/browser": "^0.10.3",

--- a/rstest/browser-rsbuild-vanilla/package.json
+++ b/rstest/browser-rsbuild-vanilla/package.json
@@ -10,7 +10,7 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rstest/browser": "^0.10.3",
     "@rstest/core": "^0.10.3",
     "@types/node": "^24.12.4",

--- a/rstest/rsbuild-adapter/package.json
+++ b/rstest/rsbuild-adapter/package.json
@@ -9,7 +9,7 @@
     "test": "rstest"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rstest/adapter-rsbuild": "^0.10.3",
     "@rstest/core": "^0.10.3",
     "@types/node": "^24.12.4",

--- a/rstest/rsbuild-preact/package.json
+++ b/rstest/rsbuild-preact/package.json
@@ -10,7 +10,7 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-preact": "^2.0.0",
     "@rstest/adapter-rsbuild": "^0.10.3",
     "@rstest/core": "^0.10.3",

--- a/rstest/rsbuild-react/package.json
+++ b/rstest/rsbuild-react/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-react": "^2.1.0",
     "@rstest/core": "^0.10.3",
     "@testing-library/jest-dom": "^6.9.1",

--- a/rstest/rsbuild-solid/package.json
+++ b/rstest/rsbuild-solid/package.json
@@ -10,7 +10,7 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-babel": "^2.0.1",
     "@rsbuild/plugin-solid": "^1.2.1",
     "@rstest/adapter-rsbuild": "^0.10.3",

--- a/rstest/rsbuild-svelte/package.json
+++ b/rstest/rsbuild-svelte/package.json
@@ -10,7 +10,7 @@
     "test:watch": "rstest --watch"
   },
   "devDependencies": {
-    "@rsbuild/core": "2.1.6",
+    "@rsbuild/core": "2.2.0-beta.1",
     "@rsbuild/plugin-svelte": "^2.0.1",
     "@rstest/adapter-rsbuild": "^0.10.3",
     "@rstest/core": "^0.10.3",

--- a/rstest/rspack-adapter/package.json
+++ b/rstest/rspack-adapter/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@rspack/cli": "2.1.4",
-    "@rspack/core": "2.1.4",
+    "@rspack/core": "2.2.0-beta.1",
     "@rspack/dev-server": "2.1.0",
     "@rspack/plugin-react-refresh": "^2.0.1",
     "@rstest/adapter-rspack": "^0.10.3",


### PR DESCRIPTION
## Summary

This updates all examples to use Rspack and Rsbuild 2.2.0-beta.1. It also upgrades the SWC Wasm plugins to their latest SWC 77-compatible releases and overrides the two stale transitive plugin versions still requested by wrapper packages.

## Related Links

- https://github.com/web-infra-dev/rspack/releases/tag/v2.2.0-beta.1
- https://github.com/web-infra-dev/rsbuild/releases/tag/v2.2.0-beta.1