### PR TITLE
fix(tanstack-start): pin solid-js to 1.x for devtools peer

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -825,6 +825,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.15)
+      solid-js:
+        specifier: ^1.9.9
+        version: 1.9.13
       typescript:
         specifier: ^6.0.3
         version: 6.0.3

--- a/rsbuild/tanstack-start/package.json
+++ b/rsbuild/tanstack-start/package.json
@@ -29,6 +29,7 @@
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
+    "solid-js": "^1.9.9",
     "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
## Why

The rspack ecosystem CI [run](https://github.com/rstackjs/rstack-ecosystem-ci/actions/runs/32443431801/job/96661612139) fails at `build:rsbuild` on `rsbuild/tanstack-start` with 64 module linking errors:

```
× ESModulesLinkingError: export 'onMount' (imported as 'onMount') was not found in 'solid-js'
× Package subpath './web' is not defined by "exports" in .../solid-js/package.json
```

`@tanstack/devtools` declares `solid-js: >=1.9.7` as a **peer** dependency. Since #495 introduced `solid-js@2.0.0-rc.0` into the workspace, a full re-resolution (which ecosystem CI triggers by injecting `@rspack/*` overrides) dedupes that peer onto `2.0.0-rc.0` instead of the package's own `solid-js: ^1.9.9` dependency. Solid 2 removed `onMount` / `batch` / `on` / `getListener` and the `./web` subpath export, so the devtools bundle no longer links.

Before / after, same install (`pnpm install --prefer-frozen-lockfile` with `@rspack/*` overrides injected):

| | `@tanstack/devtools` resolves to | `rsbuild/tanstack-start build` |
|---|---|---|
| before | `solid-js@2.0.0-rc.0` | fails, 64 errors |
| after | `solid-js@1.9.13` | passes |

## What

Declare `solid-js: ^1.9.9` in `rsbuild/tanstack-start`, so this example provides the peer itself and its subtree stays on Solid 1.x. The Solid 2 RC in `rsbuild/solid` is untouched.

Rejected alternatives: `dedupePeers: false` (does not change the resolution), and a workspace-wide `solid-js` override (would downgrade the Solid example and undo #495).

Verified locally by running the full ecosystem CI sequence — `build:rspack:eco-ci`, `test:rspack:eco-ci`, `build:rsbuild`, `build:rsdoctor`, `build:rspress`, `build:rslib` — plus `pnpm lint`.